### PR TITLE
Cb/change detection as components

### DIFF
--- a/benches/benches/bevy_ecs/change_detection.rs
+++ b/benches/benches/bevy_ecs/change_detection.rs
@@ -164,12 +164,12 @@ fn few_changed_detection_generic<T: Component + Default + BenchModify>(
                     let mut world = setup::<T>(entity_count);
                     world.clear_trackers();
                     let mut query = world.query::<&mut T>();
-                    let mut to_modify: Vec<bevy_ecs::prelude::Mut<T>> =
-                        query.iter_mut(&mut world).collect();
+                    let mut to_modify = query.iter_mut(&mut world).collect::<Vec<_>>();
                     to_modify.shuffle(&mut deterministic_rand());
                     for component in to_modify[0..amount_to_modify].iter_mut() {
                         black_box(component.bench_modify());
                     }
+                    drop(to_modify);
                     world
                 },
                 |mut world| {

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -57,6 +57,7 @@ use bevy_ecs::{
 use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath};
 use bevy_utils::{tracing::error, HashSet};
 use std::{any::TypeId, sync::Arc};
+use bevy_ecs::change_detection::ChangeTicks;
 
 #[cfg(all(feature = "file_watcher", not(feature = "multi-threaded")))]
 compile_error!(
@@ -377,6 +378,7 @@ impl AssetApp for App {
             .add_event::<AssetEvent<A>>()
             .add_event::<AssetLoadFailedEvent<A>>()
             .register_type::<Handle<A>>()
+            .register_type::<ChangeTicks<Handle<A>>>()
             .add_systems(
                 Last,
                 Assets::<A>::asset_events

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -48,6 +48,7 @@ use crate::{
     processor::{AssetProcessor, Process},
 };
 use bevy_app::{App, Last, Plugin, PreUpdate};
+use bevy_ecs::change_detection::ChangeTicks;
 use bevy_ecs::{
     reflect::AppTypeRegistry,
     schedule::{IntoSystemConfigs, IntoSystemSetConfigs, SystemSet},
@@ -57,7 +58,6 @@ use bevy_ecs::{
 use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath};
 use bevy_utils::{tracing::error, HashSet};
 use std::{any::TypeId, sync::Arc};
-use bevy_ecs::change_detection::ChangeTicks;
 
 #[cfg(all(feature = "file_watcher", not(feature = "multi-threaded")))]
 compile_error!(

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -20,9 +20,9 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
+use bevy_ecs::change_detection::ChangeTicks;
 use bevy_ecs::prelude::*;
 use std::marker::PhantomData;
-use bevy_ecs::change_detection::ChangeTicks;
 
 #[cfg(not(target_arch = "wasm32"))]
 use bevy_tasks::tick_global_task_pools_on_main_thread;

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod prelude {
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use std::marker::PhantomData;
+use bevy_ecs::change_detection::ChangeTicks;
 
 #[cfg(not(target_arch = "wasm32"))]
 use bevy_tasks::tick_global_task_pools_on_main_thread;
@@ -33,6 +34,7 @@ pub struct TypeRegistrationPlugin;
 impl Plugin for TypeRegistrationPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Name>();
+        app.register_type::<ChangeTicks<Name>>();
     }
 }
 

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -1,7 +1,9 @@
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
-use quote::{quote};
-use syn::{parse_macro_input, parse_quote, DeriveInput, Ident, LitStr, Path, Result, LitBool, TypeGenerics};
+use quote::quote;
+use syn::{
+    parse_macro_input, parse_quote, DeriveInput, Ident, LitBool, LitStr, Path, Result, TypeGenerics,
+};
 
 pub fn derive_event(input: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(input as DeriveInput);
@@ -59,8 +61,18 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
 
     let change_detection = attrs.change_detection;
-    let write_item = write_item_associated_type(&bevy_ecs_path, &struct_name, &type_generics, change_detection);
-    let change_detection_type = change_detection_associated_type(&bevy_ecs_path, &struct_name, &type_generics, change_detection);
+    let write_item = write_item_associated_type(
+        &bevy_ecs_path,
+        &struct_name,
+        &type_generics,
+        change_detection,
+    );
+    let change_detection_type = change_detection_associated_type(
+        &bevy_ecs_path,
+        &struct_name,
+        &type_generics,
+        change_detection,
+    );
 
     TokenStream::from(quote! {
         impl #impl_generics #bevy_ecs_path::component::Component for #struct_name #type_generics #where_clause {
@@ -125,7 +137,12 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
     Ok(attrs)
 }
 
-fn write_item_associated_type(bevy_ecs_path: &Path, struct_name: &Ident, type_generics: &TypeGenerics, change_detection: bool) -> TokenStream2 {
+fn write_item_associated_type(
+    bevy_ecs_path: &Path,
+    struct_name: &Ident,
+    type_generics: &TypeGenerics,
+    change_detection: bool,
+) -> TokenStream2 {
     if change_detection {
         quote! { #bevy_ecs_path::change_detection::Mut<'w, #struct_name #type_generics> }
     } else {
@@ -133,7 +150,12 @@ fn write_item_associated_type(bevy_ecs_path: &Path, struct_name: &Ident, type_ge
     }
 }
 
-fn change_detection_associated_type(bevy_ecs_path: &Path, struct_name: &Ident, type_generics: &TypeGenerics, change_detection: bool) -> TokenStream2 {
+fn change_detection_associated_type(
+    bevy_ecs_path: &Path,
+    struct_name: &Ident,
+    type_generics: &TypeGenerics,
+    change_detection: bool,
+) -> TokenStream2 {
     if change_detection {
         quote! { #bevy_ecs_path::change_detection::ChangeTicks<#struct_name #type_generics> }
     } else {

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -143,7 +143,6 @@ fn write_item_associated_type(
     }
 }
 
-
 fn storage_path(bevy_ecs_path: &Path, ty: StorageTy) -> TokenStream2 {
     let storage_type = match ty {
         StorageTy::Table => Ident::new("Table", Span::call_site()),

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -67,19 +67,12 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
         &type_generics,
         change_detection,
     );
-    let change_detection_type = change_detection_associated_type(
-        &bevy_ecs_path,
-        &struct_name,
-        &type_generics,
-        change_detection,
-    );
 
     TokenStream::from(quote! {
         impl #impl_generics #bevy_ecs_path::component::Component for #struct_name #type_generics #where_clause {
             const STORAGE_TYPE: #bevy_ecs_path::component::StorageType = #storage;
             const CHANGE_DETECTION: bool = #change_detection;
             type WriteItem<'w> = #write_item;
-            type ChangeDetection = #change_detection_type;
             fn shrink<'wlong: 'wshort, 'wshort>(item: Self::WriteItem<'wlong>) -> Self::WriteItem<'wshort> {
                 item
             }
@@ -150,18 +143,6 @@ fn write_item_associated_type(
     }
 }
 
-fn change_detection_associated_type(
-    bevy_ecs_path: &Path,
-    struct_name: &Ident,
-    type_generics: &TypeGenerics,
-    change_detection: bool,
-) -> TokenStream2 {
-    if change_detection {
-        quote! { #bevy_ecs_path::change_detection::ChangeTicks<#struct_name #type_generics> }
-    } else {
-        quote! { #bevy_ecs_path::change_detection::DisabledChangeTicks }
-    }
-}
 
 fn storage_path(bevy_ecs_path: &Path, ty: StorageTy) -> TokenStream2 {
     let storage_type = match ty {

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -63,8 +63,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     let change_detection = attrs.change_detection;
     let write_item = write_item_associated_type(
         &bevy_ecs_path,
-        &struct_name,
-        &type_generics,
+        struct_name,
+        type_generics,
         change_detection,
     );
 

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -1,7 +1,7 @@
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
-use quote::quote;
-use syn::{parse_macro_input, parse_quote, DeriveInput, Ident, LitStr, Path, Result, LitBool};
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, parse_quote, DeriveInput, Ident, LitStr, Path, Result, LitBool, TypeGenerics};
 
 pub fn derive_event(input: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(input as DeriveInput);
@@ -49,7 +49,6 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     };
 
     let storage = storage_path(&bevy_ecs_path, attrs.storage);
-    let change_detection = attrs.change_detection;
 
     ast.generics
         .make_where_clause()
@@ -59,10 +58,16 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     let struct_name = &ast.ident;
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
 
+    let change_detection = attrs.change_detection;
+    let write_fetch = write_fetch_associated_type(&bevy_ecs_path, &struct_name, &type_generics, change_detection);
+    let change_detection_type = change_detection_associated_type(&bevy_ecs_path, &struct_name, &type_generics, change_detection);
+
     TokenStream::from(quote! {
         impl #impl_generics #bevy_ecs_path::component::Component for #struct_name #type_generics #where_clause {
             const STORAGE_TYPE: #bevy_ecs_path::component::StorageType = #storage;
             const CHANGE_DETECTION: bool = #change_detection;
+            type WriteFetch<'w> = #write_fetch;
+            type ChangeDetection = #change_detection_type;
         }
     })
 }
@@ -115,6 +120,22 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
     }
 
     Ok(attrs)
+}
+
+fn write_fetch_associated_type(bevy_ecs_path: &Path, struct_name: &Ident, type_generics: &TypeGenerics, change_detection: bool) -> TokenStream2 {
+    if change_detection {
+        quote! { #bevy_ecs_path::change_detection::Mut<'w, #struct_name #type_generics> }
+    } else {
+        quote! { &'w mut #struct_name #type_generics }
+    }
+}
+
+fn change_detection_associated_type(bevy_ecs_path: &Path, struct_name: &Ident, type_generics: &TypeGenerics, change_detection: bool) -> TokenStream2 {
+    if change_detection {
+        quote! { #bevy_ecs_path::change_detection::ChangeTicks<#struct_name #type_generics> }
+    } else {
+        quote! { #bevy_ecs_path::change_detection::DisabledChangeTicks }
+    }
 }
 
 fn storage_path(bevy_ecs_path: &Path, ty: StorageTy) -> TokenStream2 {

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -61,12 +61,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
 
     let change_detection = attrs.change_detection;
-    let write_item = write_item_associated_type(
-        &bevy_ecs_path,
-        struct_name,
-        type_generics,
-        change_detection,
-    );
+    let write_item =
+        write_item_associated_type(&bevy_ecs_path, struct_name, type_generics, change_detection);
 
     TokenStream::from(quote! {
         impl #impl_generics #bevy_ecs_path::component::Component for #struct_name #type_generics #where_clause {

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -72,6 +72,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
         .map(|field| &field.ty)
         .collect::<Vec<_>>();
 
+    let mut change_ticks = Vec::new();
     let mut field_component_ids = Vec::new();
     let mut field_get_components = Vec::new();
     let mut field_from_components = Vec::new();
@@ -83,6 +84,9 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
     {
         match field_kind {
             BundleFieldKind::Component => {
+                change_ticks.push(quote! {
+                <#field_type as #ecs_path::bundle::Bundle>::ChangeTicks
+                });
                 field_component_ids.push(quote! {
                 <#field_type as #ecs_path::bundle::Bundle>::component_ids(components, storages, &mut *ids);
                 });
@@ -124,6 +128,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
         // - `Bundle::get_components` is exactly once for each member. Rely's on the Component -> Bundle implementation to properly pass
         //   the correct `StorageType` into the callback.
         unsafe impl #impl_generics #ecs_path::bundle::Bundle for #struct_name #ty_generics #where_clause {
+            type ChangeTicks = (#(#change_ticks,)*);
             fn component_ids(
                 components: &mut #ecs_path::component::Components,
                 storages: &mut #ecs_path::storage::Storages,

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -146,13 +146,13 @@ impl BundleComponentStatus for AddBundle {
     #[inline]
     unsafe fn get_component_status(&self, index: usize) -> ComponentStatus {
         // SAFETY: caller has ensured index is a valid bundle index for this bundle
-        unsafe { *self.bundle_status.get_unchecked(index).component }
+        unsafe { self.bundle_status.get_unchecked(index).component }
     }
 
     #[inline]
     unsafe fn get_component_change_status(&self, index: usize) -> ComponentStatus {
         // SAFETY: caller has ensured index is a valid bundle index for this bundle
-        unsafe { *self.bundle_status.get_unchecked(index).change_component }
+        unsafe { self.bundle_status.get_unchecked(index).change_component }
     }
 }
 

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -115,7 +115,7 @@ pub(crate) enum ComponentStatus {
 
 pub(crate) struct ComponentChangeStatus {
     pub(crate) component: ComponentStatus,
-    pub(crate) change_component: ComponentStatus,
+    pub(crate) change_component: Option<ComponentStatus>,
 }
 
 pub(crate) struct AddBundle {
@@ -136,10 +136,12 @@ pub(crate) trait BundleComponentStatus {
 
     /// Returns the Bundle's change detection component status for the given "bundle index"
     ///
+    /// Returns None if the component does not have change detection enabled.
+    ///
     /// # Safety
     /// Callers must ensure that index is always a valid bundle index for the
     /// Bundle associated with this [`BundleComponentStatus`]
-    unsafe fn get_component_change_status(&self, index: usize) -> ComponentStatus;
+    unsafe fn get_component_change_status(&self, index: usize) -> Option<ComponentStatus>;
 }
 
 impl BundleComponentStatus for AddBundle {
@@ -150,7 +152,7 @@ impl BundleComponentStatus for AddBundle {
     }
 
     #[inline]
-    unsafe fn get_component_change_status(&self, index: usize) -> ComponentStatus {
+    unsafe fn get_component_change_status(&self, index: usize) -> Option<ComponentStatus> {
         // SAFETY: caller has ensured index is a valid bundle index for this bundle
         unsafe { self.bundle_status.get_unchecked(index).change_component }
     }
@@ -166,9 +168,10 @@ impl BundleComponentStatus for SpawnBundleStatus {
     }
 
     #[inline]
-    unsafe fn get_component_change_status(&self, _index: usize) -> ComponentStatus {
+    unsafe fn get_component_change_status(&self, _index: usize) -> Option<ComponentStatus> {
+        // TODO: be able to handle components with no change detection!!
         // Change detection added during a spawn call are always treated as added
-        ComponentStatus::Added
+        Some(ComponentStatus::Added)
     }
 }
 

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -507,6 +507,8 @@ impl BundleInfo {
                                 });
                             },
                             ComponentStatus::Mutated => {
+                                // SAFETY: If component_id is in self.component_ids, BundleInfo::new requires that
+                                // a sparse set exists for the component.
                                 let ptr = unsafe { change_sparse_set.get(entity).debug_checked_unwrap() };
                                 ptr.assert_unique().deref_mut::<ComponentTicks>().changed = change_tick;
                             },
@@ -569,10 +571,10 @@ impl BundleInfo {
                                 unsafe { components.get_info_unchecked(change_component_id) };
                             match component_info.storage_type() {
                                 StorageType::Table => {
-                                    new_table_components.push(change_component_id)
+                                    new_table_components.push(change_component_id);
                                 }
                                 StorageType::SparseSet => {
-                                    new_sparse_set_components.push(change_component_id)
+                                    new_sparse_set_components.push(change_component_id);
                                 }
                             }
                             ComponentStatus::Added
@@ -926,7 +928,7 @@ impl<'w> BundleInserter<'w> {
                     bundle_info
                         .iter_components()
                         .zip(add_bundle.bundle_status.iter())
-                        .filter(|(_, &ref status)| status.component == ComponentStatus::Added)
+                        .filter(|(_, status)| status.component == ComponentStatus::Added)
                         .map(|(id, _)| id),
                 );
             }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -506,15 +506,12 @@ impl BundleInfo {
             // handle the change detection component in a separate loop to maintain the order
             // between the component and its change detection component
             let change_component_id = component_change_id.change_ticks_component;
+            // TODO: can we avoid this check and re-use the main component's Status?
             let change_component_status = if current_archetype.contains(change_component_id) {
                 ComponentStatus::Mutated
             } else {
-                // SAFETY: component_id exists
-                let component_info = unsafe { components.get_info_unchecked(component_id) };
-                match component_info.storage_type() {
-                    StorageType::Table => new_table_components.push(component_id),
-                    StorageType::SparseSet => new_sparse_set_components.push(component_id),
-                }
+                // tick components are always stored in tables
+                new_table_components.push(change_component_id);
                 ComponentStatus::Added
             };
             bundle_status.push(ComponentChangeStatus {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -6,7 +6,7 @@ pub use bevy_ecs_macros::Bundle;
 use bevy_utils::{HashMap, HashSet, TypeIdMap};
 
 use crate::archetype::ComponentChangeStatus;
-use crate::change_detection::{ChangeTicks, ComponentChangeId};
+use crate::change_detection::ComponentChangeId;
 use crate::component::ComponentTicks;
 use crate::{
     archetype::{

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -865,7 +865,7 @@ impl<'w> BundleInserter<'w> {
                     bundle_info
                         .iter_components()
                         .zip(add_bundle.bundle_status.iter())
-                        .filter(|(_, &status)| status.component == ComponentStatus::Added)
+                        .filter(|(_, &ref status)| status.component == ComponentStatus::Added)
                         .map(|(id, _)| id),
                 );
             }
@@ -1063,7 +1063,7 @@ impl Bundles {
                 change_component_ids.push(id);
             });
             // it is guaranteed that each component_id has a corresponding change_component_id
-            let mut component_change_ids = component_ids
+            let component_change_ids = component_ids
                 .into_iter()
                 .zip(change_component_ids.into_iter())
                 .map(|(component_id, change_component_id)| {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -6,7 +6,7 @@ pub use bevy_ecs_macros::Bundle;
 use bevy_utils::{HashMap, HashSet, TypeIdMap};
 
 use crate::archetype::ComponentChangeStatus;
-use crate::change_detection::ComponentChangeId;
+use crate::change_detection::{ChangeTicks, ComponentChangeId};
 use crate::component::ComponentTicks;
 use crate::{
     archetype::{
@@ -210,7 +210,7 @@ unsafe impl<C: Component> Bundle for C {
             ComponentChangeId {
                 component: component_id,
                 change_ticks_component: C::CHANGE_DETECTION
-                    .then(|| components.init_component::<C::ChangeDetection>(storages)),
+                    .then(|| components.init_component::<ChangeTicks<C>>(storages)),
             }
         });
     }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -228,7 +228,7 @@ macro_rules! tuple_impl {
         // - `Bundle::get_components` is called exactly once for each member. Relies on the above implementation to pass the correct
         //   `StorageType` into the callback.
         unsafe impl<$($name: Bundle),*> Bundle for ($($name,)*) {
-            type ChangeTicks: ($($name::ChangeTicks,)*);
+            type ChangeTicks = ($($name::ChangeTicks,)*);
 
             #[allow(unused_variables)]
             fn component_ids(components: &mut Components, storages: &mut Storages, ids: &mut impl FnMut(ComponentId)){
@@ -865,7 +865,7 @@ impl<'w> BundleInserter<'w> {
                     bundle_info
                         .iter_components()
                         .zip(add_bundle.bundle_status.iter())
-                        .filter(|(_, &status)| status == ComponentStatus::Added)
+                        .filter(|(_, &status)| status.component == ComponentStatus::Added)
                         .map(|(id, _)| id),
                 );
             }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -554,8 +554,12 @@ impl BundleInfo {
                         if current_archetype.contains(change_component_id) {
                             ComponentStatus::Mutated
                         } else {
-                            // tick components are always stored in tables
-                            new_table_components.push(change_component_id);
+                            // SAFETY: change_componeny_id exists
+                            let component_info = unsafe { components.get_info_unchecked(change_component_id) };
+                            match component_info.storage_type() {
+                                StorageType::Table => new_table_components.push(change_component_id),
+                                StorageType::SparseSet => new_sparse_set_components.push(change_component_id),
+                            }
                             ComponentStatus::Added
                         }
                     });

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -513,7 +513,7 @@ pub struct ChangeTicks<T: Component> {
     _marker: PhantomData<T>,
 }
 
-/// Manual implementation so that ChangeTicks can use the same storage type as the inner component.
+/// Manual implementation so that `ChangeTicks` can use the same storage type as the inner component.
 impl<T: Component> Component for ChangeTicks<T> {
     const STORAGE_TYPE: StorageType = T::STORAGE_TYPE;
     const CHANGE_DETECTION: bool = false;
@@ -853,10 +853,10 @@ impl_debug!(Mut<'w, T>,);
 
 /// Mutable fetch item that can be built from a mutable reference to the inner value.
 pub trait MutFetchItem<'a>: DerefMut + Sized {
-    /// the ReadOnlyQueryData that corresponds to this MutFetchItem
+    /// the `ReadOnlyQueryData` that corresponds to this `MutFetchItem`
     type ReadOnly: Deref<Target = Self::Target>;
 
-    /// Build the MutFetchItem from the inner value and the `TicksMut`
+    /// Build the `MutFetchItem` from the inner value and the `TicksMut`
     fn build(inner: &'a mut Self::Target, ticks_mut: Option<TicksMut<'a>>) -> Self;
 }
 

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -878,6 +878,31 @@ impl<'a, T: Component> MutFetchItem<'a> for &'a mut T {
     }
 }
 
+impl<'a, T: Component> DetectChanges for &'a mut T {
+    fn is_added(&self) -> bool {
+        true
+    }
+
+    fn is_changed(&self) -> bool {
+        true
+    }
+
+    fn last_changed(&self) -> Tick {
+        Tick::new(0)
+    }
+}
+impl<'a, T: Component> DetectChangesMut for &'a mut T {
+    type Inner = T;
+
+    fn set_changed(&mut self) {}
+
+    fn set_last_changed(&mut self, last_changed: Tick) {}
+
+    fn bypass_change_detection(&mut self) -> &mut Self::Inner {
+        self
+    }
+}
+
 /// Unique mutable borrow of resources or an entity's component.
 ///
 /// Similar to [`Mut`], but not generic over the component type, instead

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -368,7 +368,7 @@ macro_rules! impl_methods {
             /// # impl Vec2 { pub const ZERO: Self = Self; }
             /// # #[derive(Component)] pub struct Transform { translation: Vec2 }
             /// // When run, zeroes the translation of every entity.
-            /// fn reset_positions(mut transforms: Query<&mut Transform>) {
+            /// fn reset_positions(mut transforms: Query<Mut<Transform>>) {
             ///     for transform in &mut transforms {
             ///         // We pinky promise not to modify `t` within the closure.
             ///         // Breaking this promise will result in logic errors, but will never cause undefined behavior.

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -8,6 +8,8 @@ use crate::{
 use bevy_ptr::{Ptr, UnsafeCellDeref};
 use std::mem;
 use std::ops::{Deref, DerefMut};
+use bevy_ecs_macros::Component;
+use crate::component::Component;
 
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
 ///
@@ -474,6 +476,16 @@ impl<'w> From<TicksMut<'w>> for Ticks<'w> {
         }
     }
 }
+
+// TODO: add docs
+#[derive(Component, Clone)]
+pub(crate) struct ChangeTicks<T: Component>{
+    /// The [`Tick`] indicating when the component was added.
+    pub(crate) added: Tick,
+    /// The [`Tick`] indicating when the component was last changed.
+    pub(crate) changed: Tick,
+}
+
 
 /// Shared borrow of a [`Resource`].
 ///

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -8,10 +8,10 @@ use crate::{
     system::Resource,
 };
 use bevy_ptr::{Ptr, UnsafeCellDeref};
+use bevy_reflect::Reflect;
 use std::marker::PhantomData;
 use std::mem;
 use std::ops::{Deref, DerefMut};
-use bevy_reflect::Reflect;
 
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
 ///
@@ -881,7 +881,6 @@ impl<'a, T: Component> MutFetchItem<'a> for &'a mut T {
         value
     }
 }
-
 
 impl<'a, T: Component> DetectChanges for &'a mut T {
     fn is_added(&self) -> bool {

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -9,7 +9,7 @@ use crate::{
 use bevy_ptr::{Ptr, UnsafeCellDeref};
 use std::mem;
 use std::ops::{Deref, DerefMut};
-use bevy_ecs_macros::Component;
+use crate as bevy_ecs;
 use crate::component::{Component, ComponentId, ComponentTicks};
 
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
@@ -480,7 +480,8 @@ impl<'w> From<TicksMut<'w>> for Ticks<'w> {
 
 // TODO: add docs
 #[derive(Component, Clone)]
-pub(crate) struct ChangeTicks<T: Component>{
+#[component(change_detection = false)]
+pub struct ChangeTicks<T: Component>{
     ticks: ComponentTicks,
     _marker: PhantomData<T>,
 }

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -529,7 +529,7 @@ pub struct ChangeTicks<T: Component>{
 pub struct ComponentChangeId {
     pub(crate) component: ComponentId,
     // TODO: make this optional is change detection is disabled for this component?
-    pub(crate) change_ticks_component: ComponentId,
+    pub(crate) change_ticks_component: Option<ComponentId>,
 }
 
 

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -896,7 +896,7 @@ impl<'a, T: Component> DetectChangesMut for &'a mut T {
 
     fn set_changed(&mut self) {}
 
-    fn set_last_changed(&mut self, last_changed: Tick) {}
+    fn set_last_changed(&mut self, _last_changed: Tick) {}
 
     fn bypass_change_detection(&mut self) -> &mut Self::Inner {
         self

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -1,17 +1,17 @@
 //! Types that detect when their internal data mutate.
 
-use std::cell::UnsafeCell;
-use std::marker::PhantomData;
+use crate as bevy_ecs;
+use crate::component::{Component, ComponentId, ComponentTicks};
 use crate::{
     component::{Tick, TickCells},
     ptr::PtrMut,
     system::Resource,
 };
 use bevy_ptr::{Ptr, UnsafeCellDeref};
+use std::cell::UnsafeCell;
+use std::marker::PhantomData;
 use std::mem;
 use std::ops::{Deref, DerefMut};
-use crate as bevy_ecs;
-use crate::component::{Component, ComponentId, ComponentTicks};
 
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
 ///
@@ -518,11 +518,10 @@ impl<'w> From<TicksMut<'w>> for Ticks<'w> {
 // TODO: add docs
 #[derive(Component, Clone)]
 #[component(change_detection = false)]
-pub struct ChangeTicks<T: Component>{
+pub struct ChangeTicks<T: Component> {
     ticks: ComponentTicks,
     _marker: PhantomData<T>,
 }
-
 
 /// Stores the component's [`ComponentId`] as well as the id of the component storing the change ticks.
 #[derive(Copy, Clone, Hash, Debug, Ord, PartialOrd, Eq, PartialEq)]
@@ -531,7 +530,6 @@ pub struct ComponentChangeId {
     // TODO: make this optional is change detection is disabled for this component?
     pub(crate) change_ticks_component: Option<ComponentId>,
 }
-
 
 /// Shared borrow of a [`Resource`].
 ///

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -1,5 +1,6 @@
 //! Types that detect when their internal data mutate.
 
+use std::marker::PhantomData;
 use crate::{
     component::{Tick, TickCells},
     ptr::PtrMut,
@@ -9,7 +10,7 @@ use bevy_ptr::{Ptr, UnsafeCellDeref};
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use bevy_ecs_macros::Component;
-use crate::component::Component;
+use crate::component::{Component, ComponentId, ComponentTicks};
 
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
 ///
@@ -480,10 +481,17 @@ impl<'w> From<TicksMut<'w>> for Ticks<'w> {
 // TODO: add docs
 #[derive(Component, Clone)]
 pub(crate) struct ChangeTicks<T: Component>{
-    /// The [`Tick`] indicating when the component was added.
-    pub(crate) added: Tick,
-    /// The [`Tick`] indicating when the component was last changed.
-    pub(crate) changed: Tick,
+    ticks: ComponentTicks,
+    _marker: PhantomData<T>,
+}
+
+
+/// Stores the component's [`ComponentId`] as well as the id of the component storing the change ticks.
+#[derive(Copy, Clone, Hash, Debug, Ord, PartialOrd, Eq, PartialEq)]
+pub(crate) struct ComponentChangeId {
+    pub(crate) component: ComponentId,
+    // TODO: make this optional is change detection is disabled for this component?
+    pub(crate) change_ticks_component: ComponentId,
 }
 
 

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1,6 +1,6 @@
 //! Types for declaring and storing [`Component`]s.
 
-use crate::change_detection::{ChangeTicks, MutFetchItem};
+use crate::change_detection::{ChangeTicks, DetectChangesMut, MutFetchItem};
 use crate::{
     self as bevy_ecs,
     archetype::ArchetypeFlags,
@@ -158,7 +158,7 @@ pub trait Component: Send + Sync + 'static {
     const CHANGE_DETECTION: bool;
     // TODO: should we also have a ReadFetch that returns a &T if change detection is disabled?
     /// The type of the Fetch returned when querying for &mut T
-    type WriteItem<'w>: std::ops::DerefMut<Target = Self> + MutFetchItem<'w>;
+    type WriteItem<'w>: std::ops::DerefMut<Target = Self> + MutFetchItem<'w> + DetectChangesMut;
 
     /// Called when registering this component, allowing mutable access to it's [`ComponentHooks`].
     fn register_component_hooks(_hooks: &mut ComponentHooks) {}
@@ -166,11 +166,6 @@ pub trait Component: Send + Sync + 'static {
     /// Shrink the given item to a shorter lifetime
     fn shrink<'wlong: 'wshort, 'wshort>(item: Self::WriteItem<'wlong>) -> Self::WriteItem<'wshort>;
 }
-
-/// A component used to symbolize the absence of change detection
-#[derive(Component)]
-#[component(change_detection = false)]
-pub struct DisabledChangedTicks;
 
 /// The storage used for a specific component type.
 ///

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -154,7 +154,7 @@ use std::{
 pub trait Component: Send + Sync + 'static {
     /// A constant indicating the storage type used for this component.
     const STORAGE_TYPE: StorageType;
-    /// Whether or not ChangeDetection is enabled
+    /// Whether or not change detection is enabled
     const CHANGE_DETECTION: bool;
     // TODO: should we also have a ReadFetch that returns a &T if change detection is disabled?
     /// The type of the Fetch returned when querying for &mut T

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1,6 +1,6 @@
 //! Types for declaring and storing [`Component`]s.
 
-use crate::change_detection::{MutFetchItem};
+use crate::change_detection::MutFetchItem;
 use crate::{
     self as bevy_ecs,
     archetype::ArchetypeFlags,
@@ -156,7 +156,7 @@ pub trait Component: Send + Sync + 'static {
     const STORAGE_TYPE: StorageType;
     // TODO: should we also have a ReadFetch that returns a &T if change detection is disabled?
     /// The type of the Fetch returned when querying for &mut T
-    type WriteItem<'w>: std::ops::DerefMut<Target=Self> + MutFetchItem<'w>;
+    type WriteItem<'w>: std::ops::DerefMut<Target = Self> + MutFetchItem<'w>;
     /// The type of the ChangeDetection component associated with this component.
     type ChangeDetection: Component;
     /// Whether or not ChangeDetection is enabled
@@ -173,7 +173,6 @@ pub trait Component: Send + Sync + 'static {
 #[derive(Component)]
 #[component(change_detection = false)]
 pub struct DisabledChangedTicks;
-
 
 /// The storage used for a specific component type.
 ///

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1,6 +1,6 @@
 //! Types for declaring and storing [`Component`]s.
 
-use crate::change_detection::ChangeTicks;
+use crate::change_detection::{MutFetchItem};
 use crate::{
     self as bevy_ecs,
     archetype::ArchetypeFlags,
@@ -156,7 +156,7 @@ pub trait Component: Send + Sync + 'static {
     const STORAGE_TYPE: StorageType;
     // TODO: should we also have a ReadFetch that returns a &T if change detection is disabled?
     /// The type of the Fetch returned when querying for &mut T
-    type WriteFetch<'w>: std::ops::DerefMut<Target=Self>;
+    type WriteItem<'w>: std::ops::DerefMut<Target=Self> + MutFetchItem<'w>;
     /// The type of the ChangeDetection component associated with this component.
     type ChangeDetection: Component;
     /// Whether or not ChangeDetection is enabled
@@ -164,6 +164,9 @@ pub trait Component: Send + Sync + 'static {
 
     /// Called when registering this component, allowing mutable access to it's [`ComponentHooks`].
     fn register_component_hooks(_hooks: &mut ComponentHooks) {}
+
+    /// Shrink the given item to a shorter lifetime
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::WriteItem<'wlong>) -> Self::WriteItem<'wshort>;
 }
 
 /// A component used to symbolize the absence of change detection

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -595,7 +595,7 @@ impl Components {
             storage_type: StorageType::Table,
             is_send_and_sync: true,
             type_id: None,
-            layout: Layout::new::<ChangeTicks<()>>(),
+            layout: Layout::new::<ComponentTicks>(),
             drop: None,
         };
         let change_detection_id = Components::init_component_inner(&mut self.components, storages, change_ticks_descriptor, None);

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -59,7 +59,7 @@ mod tests {
     use crate::prelude::Or;
     use crate::{
         bundle::Bundle,
-        change_detection::Ref,
+        change_detection::{Ref},
         component::{Component, ComponentId},
         entity::Entity,
         query::{Added, Changed, FilteredAccess, QueryFilter, With, Without},

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -56,10 +56,11 @@ pub mod prelude {
 #[cfg(test)]
 mod tests {
     use crate as bevy_ecs;
+    use crate::change_detection::ChangeTicks;
     use crate::prelude::Or;
     use crate::{
         bundle::Bundle,
-        change_detection::{Ref},
+        change_detection::Ref,
         component::{Component, ComponentId},
         entity::Entity,
         query::{Added, Changed, FilteredAccess, QueryFilter, With, Without},
@@ -76,7 +77,6 @@ mod tests {
             Arc, Mutex,
         },
     };
-    use crate::change_detection::ChangeTicks;
 
     #[derive(Component, Resource, Debug, PartialEq, Eq, Clone, Copy)]
     struct A(usize);
@@ -1377,7 +1377,10 @@ mod tests {
 
         let mut expected = FilteredAccess::<ComponentId>::default();
         let a_id = world.components.get_id(TypeId::of::<A>()).unwrap();
-        let b_tick_id = world.components.get_id(TypeId::of::<ChangeTicks<B>>()).unwrap();
+        let b_tick_id = world
+            .components
+            .get_id(TypeId::of::<ChangeTicks<B>>())
+            .unwrap();
         expected.add_write(a_id);
         expected.add_read(b_tick_id);
         assert!(
@@ -1393,8 +1396,14 @@ mod tests {
 
         let mut expected = FilteredAccess::<ComponentId>::default();
         let a_id = world.components.get_id(TypeId::of::<A>()).unwrap();
-        let a_tick_id = world.components.get_id(TypeId::of::<ChangeTicks<A>>()).unwrap();
-        let b_tick_id = world.components.get_id(TypeId::of::<ChangeTicks<B>>()).unwrap();
+        let a_tick_id = world
+            .components
+            .get_id(TypeId::of::<ChangeTicks<A>>())
+            .unwrap();
+        let b_tick_id = world
+            .components
+            .get_id(TypeId::of::<ChangeTicks<B>>())
+            .unwrap();
         expected.add_write(a_id);
         expected.add_write(a_tick_id);
         expected.add_read(b_tick_id);

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1377,7 +1377,10 @@ mod tests {
 
         let mut expected = FilteredAccess::<ComponentId>::default();
         let a_id = world.components.get_id(TypeId::of::<A>()).unwrap();
-        let a_ticks_id = world.components.get_id(TypeId::of::<ChangeTicks<A>>()).unwrap();
+        let a_ticks_id = world
+            .components
+            .get_id(TypeId::of::<ChangeTicks<A>>())
+            .unwrap();
         let b_ticks_id = world
             .components
             .get_id(TypeId::of::<ChangeTicks<B>>())

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -904,7 +904,7 @@ mod tests {
 
         world.clear_trackers();
 
-        for (i, mut a) in world.query::<Mut<A>>().iter_mut(&mut world).enumerate() {
+        for (i, mut a) in world.query::<&mut A>().iter_mut(&mut world).enumerate() {
             if i % 2 == 0 {
                 a.0 += 1;
             }
@@ -984,7 +984,7 @@ mod tests {
         world.clear_trackers();
 
         for (i, mut a) in world
-            .query::<Mut<SparseStored>>()
+            .query::<&mut SparseStored>()
             .iter_mut(&mut world)
             .enumerate()
         {
@@ -1392,7 +1392,7 @@ mod tests {
     #[test]
     fn filtered_query_access_mut() {
         let mut world = World::new();
-        let query = world.query_filtered::<Mut<A>, Changed<B>>();
+        let query = world.query_filtered::<&mut A, Changed<B>>();
 
         let mut expected = FilteredAccess::<ComponentId>::default();
         let a_id = world.components.get_id(TypeId::of::<A>()).unwrap();

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1377,12 +1377,14 @@ mod tests {
 
         let mut expected = FilteredAccess::<ComponentId>::default();
         let a_id = world.components.get_id(TypeId::of::<A>()).unwrap();
-        let b_tick_id = world
+        let a_ticks_id = world.components.get_id(TypeId::of::<ChangeTicks<A>>()).unwrap();
+        let b_ticks_id = world
             .components
             .get_id(TypeId::of::<ChangeTicks<B>>())
             .unwrap();
         expected.add_write(a_id);
-        expected.add_read(b_tick_id);
+        expected.add_write(a_ticks_id);
+        expected.add_read(b_ticks_id);
         assert!(
             query.component_access.eq(&expected),
             "ComponentId access from query fetch and query filter should be combined"

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -76,6 +76,7 @@ mod tests {
             Arc, Mutex,
         },
     };
+    use crate::change_detection::ChangeTicks;
 
     #[derive(Component, Resource, Debug, PartialEq, Eq, Clone, Copy)]
     struct A(usize);
@@ -903,7 +904,7 @@ mod tests {
 
         world.clear_trackers();
 
-        for (i, mut a) in world.query::<&mut A>().iter_mut(&mut world).enumerate() {
+        for (i, mut a) in world.query::<Mut<A>>().iter_mut(&mut world).enumerate() {
             if i % 2 == 0 {
                 a.0 += 1;
             }
@@ -983,7 +984,7 @@ mod tests {
         world.clear_trackers();
 
         for (i, mut a) in world
-            .query::<&mut SparseStored>()
+            .query::<Mut<SparseStored>>()
             .iter_mut(&mut world)
             .enumerate()
         {
@@ -1376,9 +1377,27 @@ mod tests {
 
         let mut expected = FilteredAccess::<ComponentId>::default();
         let a_id = world.components.get_id(TypeId::of::<A>()).unwrap();
-        let b_id = world.components.get_id(TypeId::of::<B>()).unwrap();
+        let b_tick_id = world.components.get_id(TypeId::of::<ChangeTicks<B>>()).unwrap();
         expected.add_write(a_id);
-        expected.add_read(b_id);
+        expected.add_read(b_tick_id);
+        assert!(
+            query.component_access.eq(&expected),
+            "ComponentId access from query fetch and query filter should be combined"
+        );
+    }
+
+    #[test]
+    fn filtered_query_access_mut() {
+        let mut world = World::new();
+        let query = world.query_filtered::<Mut<A>, Changed<B>>();
+
+        let mut expected = FilteredAccess::<ComponentId>::default();
+        let a_id = world.components.get_id(TypeId::of::<A>()).unwrap();
+        let a_tick_id = world.components.get_id(TypeId::of::<ChangeTicks<A>>()).unwrap();
+        let b_tick_id = world.components.get_id(TypeId::of::<ChangeTicks<B>>()).unwrap();
+        expected.add_write(a_id);
+        expected.add_write(a_tick_id);
+        expected.add_read(b_tick_id);
         assert!(
             query.component_access.eq(&expected),
             "ComponentId access from query fetch and query filter should be combined"

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1304,7 +1304,6 @@ unsafe impl<T: Component> WorldQuery for &mut T {
         } else {
             // SAFETY: we have initialized the component so the component_info exists;
             let component_info = world.components.get_info(component_id).unwrap();
-            // TODO: handle cases where the change detection is disabled!
             // SAFETY: we know that change detection is enabled, so the change detection id is present
             let change_component_id = component_info
                 .change_detection_id()

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -926,17 +926,18 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
                         .debug_checked_unwrap()
                 }
             }),
-            sparse_tick_data: ((T::STORAGE_TYPE == StorageType::SparseSet) && T::CHANGE_DETECTION).then(|| {
-                // SAFETY: if change detection is enabled, the change_ticks_component is guaranteed to exists
-                // and it uses the same storage type as the original component
-                unsafe {
-                    world
-                        .storages()
-                        .sparse_sets
-                        .get(component_id.change_ticks_component.unwrap())
-                        .debug_checked_unwrap()
-                }
-            }),
+            sparse_tick_data: ((T::STORAGE_TYPE == StorageType::SparseSet) && T::CHANGE_DETECTION)
+                .then(|| {
+                    // SAFETY: if change detection is enabled, the change_ticks_component is guaranteed to exists
+                    // and it uses the same storage type as the original component
+                    unsafe {
+                        world
+                            .storages()
+                            .sparse_sets
+                            .get(component_id.change_ticks_component.unwrap())
+                            .debug_checked_unwrap()
+                    }
+                }),
             last_run,
             this_run,
         }
@@ -1013,7 +1014,8 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
                 // SAFETY: The caller ensures `entity` is in range.
                 let component = unsafe { component_sparse_set.get(entity).debug_checked_unwrap() };
 
-                let change_ticks_sparse_set = unsafe { fetch.sparse_tick_data.debug_checked_unwrap() };
+                let change_ticks_sparse_set =
+                    unsafe { fetch.sparse_tick_data.debug_checked_unwrap() };
 
                 let ticks = unsafe { change_ticks_sparse_set.get(entity).debug_checked_unwrap() };
                 (component.deref(), ticks.deref())
@@ -1158,17 +1160,18 @@ unsafe impl<T: Component> WorldQuery for &mut T {
                         .debug_checked_unwrap()
                 }
             }),
-            sparse_tick_data: ((T::STORAGE_TYPE == StorageType::SparseSet) && T::CHANGE_DETECTION).then(|| {
-                // SAFETY: if change detection is enabled, the change_ticks_component is guaranteed to exists
-                // and it uses the same storage type as the original component
-                unsafe {
-                    world
-                        .storages()
-                        .sparse_sets
-                        .get(component_id.change_ticks_component.unwrap())
-                        .debug_checked_unwrap()
-                }
-            }),
+            sparse_tick_data: ((T::STORAGE_TYPE == StorageType::SparseSet) && T::CHANGE_DETECTION)
+                .then(|| {
+                    // SAFETY: if change detection is enabled, the change_ticks_component is guaranteed to exists
+                    // and it uses the same storage type as the original component
+                    unsafe {
+                        world
+                            .storages()
+                            .sparse_sets
+                            .get(component_id.change_ticks_component.unwrap())
+                            .debug_checked_unwrap()
+                    }
+                }),
             // TODO: remove these from fetch if change detection is disabled?
             last_run,
             this_run,
@@ -1305,9 +1308,7 @@ unsafe impl<T: Component> WorldQuery for &mut T {
             // SAFETY: we have initialized the component so the component_info exists;
             let component_info = world.components.get_info(component_id).unwrap();
             // SAFETY: we know that change detection is enabled, so the change detection id is present
-            let change_component_id = component_info
-                .change_detection_id()
-                .unwrap();
+            let change_component_id = component_info.change_detection_id().unwrap();
             ComponentChangeId {
                 component: component_id,
                 change_ticks_component: Some(change_component_id),
@@ -1324,8 +1325,7 @@ unsafe impl<T: Component> WorldQuery for &mut T {
             })
         } else {
             world.components.get_info(component_id).and_then(|info| {
-                let change_component_id = info
-                    .change_detection_id()?;
+                let change_component_id = info.change_detection_id()?;
                 Some(ComponentChangeId {
                     component: component_id,
                     change_ticks_component: Some(change_component_id),
@@ -1359,12 +1359,9 @@ unsafe impl<T: Component> WorldQuery for &mut T {
 // }
 
 /// SAFETY: `Self` is the same as `Self::ReadOnly`
-unsafe impl<'w, T: Component> QueryData for &'w mut T
-{
+unsafe impl<'w, T: Component> QueryData for &'w mut T {
     type ReadOnly = &'w T;
 }
-
-
 
 #[doc(hidden)]
 pub struct OptionFetch<'w, T: WorldQuery> {

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1,4 +1,4 @@
-use crate::change_detection::{ChangeTicks, ComponentChangeId};
+use crate::change_detection::{ChangeTicks, ComponentChangeId, MutFetchItem};
 use crate::component::ComponentTicks;
 use crate::{
     archetype::Archetype,
@@ -9,7 +9,7 @@ use crate::{
     storage::{ComponentSparseSet, Table, TableRow},
     world::{
         unsafe_world_cell::UnsafeWorldCell, EntityMut, EntityRef, FilteredEntityMut,
-        FilteredEntityRef, Mut, Ref, World,
+        FilteredEntityRef, Ref, World,
     },
 };
 use bevy_ptr::{ThinSlicePtr, UnsafeCellDeref};
@@ -734,7 +734,8 @@ impl<T> Copy for ReadFetch<'_, T> {}
 unsafe impl<T: Component> WorldQuery for &T {
     type Item<'w> = &'w T;
     type Fetch<'w> = ReadFetch<'w, T>;
-    type State = ComponentId;
+    // Use `ComponentChangeId` as `State` to allow transmutes between Mut<C> and &C
+    type State = ComponentChangeId;
 
     fn shrink<'wlong: 'wshort, 'wshort>(item: &'wlong T) -> &'wshort T {
         item
@@ -743,7 +744,7 @@ unsafe impl<T: Component> WorldQuery for &T {
     #[inline]
     unsafe fn init_fetch<'w>(
         world: UnsafeWorldCell<'w>,
-        &component_id: &ComponentId,
+        &component_id: &ComponentChangeId,
         _last_run: Tick,
         _this_run: Tick,
     ) -> ReadFetch<'w, T> {
@@ -758,7 +759,7 @@ unsafe impl<T: Component> WorldQuery for &T {
                     world
                         .storages()
                         .sparse_sets
-                        .get(component_id)
+                        .get(component_id.component)
                         .debug_checked_unwrap()
                 }
             }),
@@ -775,7 +776,7 @@ unsafe impl<T: Component> WorldQuery for &T {
     #[inline]
     unsafe fn set_archetype<'w>(
         fetch: &mut ReadFetch<'w, T>,
-        component_id: &ComponentId,
+        component_id: &ComponentChangeId,
         _archetype: &'w Archetype,
         table: &'w Table,
     ) {
@@ -790,12 +791,12 @@ unsafe impl<T: Component> WorldQuery for &T {
     #[inline]
     unsafe fn set_table<'w>(
         fetch: &mut ReadFetch<'w, T>,
-        &component_id: &ComponentId,
+        &component_id: &ComponentChangeId,
         table: &'w Table,
     ) {
         fetch.table_components = Some(
             table
-                .get_column(component_id)
+                .get_column(component_id.component)
                 .debug_checked_unwrap()
                 .get_data_slice()
                 .into(),
@@ -827,30 +828,36 @@ unsafe impl<T: Component> WorldQuery for &T {
     }
 
     fn update_component_access(
-        &component_id: &ComponentId,
+        &component_id: &ComponentChangeId,
         access: &mut FilteredAccess<ComponentId>,
     ) {
         assert!(
-            !access.access().has_write(component_id),
+            !access.access().has_write(component_id.component),
             "&{} conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",
                 std::any::type_name::<T>(),
         );
-        access.add_read(component_id);
+        access.add_read(component_id.component);
     }
 
-    fn init_state(world: &mut World) -> ComponentId {
-        world.init_component::<T>()
+    fn init_state(world: &mut World) -> ComponentChangeId {
+        ComponentChangeId {
+            component: world.init_component::<T>(),
+            change_ticks_component: None,
+        }
     }
 
     fn get_state(world: &World) -> Option<Self::State> {
-        world.component_id::<T>()
+        Some(ComponentChangeId {
+            component: world.component_id::<T>()?,
+            change_ticks_component: None,
+        })
     }
 
     fn matches_component_set(
-        &state: &ComponentId,
+        &state: &ComponentChangeId,
         set_contains_id: &impl Fn(ComponentId) -> bool,
     ) -> bool {
-        set_contains_id(state)
+        set_contains_id(state.component)
     }
 }
 
@@ -866,10 +873,10 @@ unsafe impl<T: Component> ReadOnlyQueryData for &T {}
 pub struct RefFetch<'w, T> {
     // T::STORAGE_TYPE = StorageType::Table
     table_data: Option<ThinSlicePtr<'w, UnsafeCell<T>>>,
+    table_tick_data: Option<ThinSlicePtr<'w, UnsafeCell<ComponentTicks>>>,
     // T::STORAGE_TYPE = StorageType::SparseSet
     sparse_set: Option<&'w ComponentSparseSet>,
-
-    tick_data: Option<ThinSlicePtr<'w, UnsafeCell<ComponentTicks>>>,
+    sparse_tick_data: Option<&'w ComponentSparseSet>,
 
     last_run: Tick,
     this_run: Tick,
@@ -905,6 +912,7 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
     ) -> RefFetch<'w, T> {
         RefFetch {
             table_data: None,
+            table_tick_data: None,
             sparse_set: (T::STORAGE_TYPE == StorageType::SparseSet).then(|| {
                 // SAFETY: The underlying type associated with `component_id` is `T`,
                 // which we are allowed to access since we registered it in `update_archetype_component_access`.
@@ -918,7 +926,17 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
                         .debug_checked_unwrap()
                 }
             }),
-            tick_data: None,
+            sparse_tick_data: ((T::STORAGE_TYPE == StorageType::SparseSet) && T::CHANGE_DETECTION).then(|| {
+                // SAFETY: if change detection is enabled, the change_ticks_component is guaranteed to exists
+                // and it uses the same storage type as the original component
+                unsafe {
+                    world
+                        .storages()
+                        .sparse_sets
+                        .get(component_id.change_ticks_component.unwrap())
+                        .debug_checked_unwrap()
+                }
+            }),
             last_run,
             this_run,
         }
@@ -938,22 +956,10 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
         _archetype: &'w Archetype,
         table: &'w Table,
     ) {
-        // TODO: 2 options
-        //  - panic if we use Ref<> for a component that does not have change detection
-        //  - or just convert to a normal &T in that case? (return without change ticks?)
-        let change_component_id = component_id
-            .change_ticks_component
-            .expect("change detection is disabled for this component");
-        // SAFETY: if change detection is enabled, the change ticks are present in the same table
-        let change_column = table.get_column(change_component_id).debug_checked_unwrap();
-        fetch.tick_data = Some(change_column.get_data_slice().into());
         if Self::IS_DENSE {
             // SAFETY: `set_archetype`'s safety rules are a super set of the `set_table`'s ones.
             unsafe {
-                let column = table
-                    .get_column(component_id.component)
-                    .debug_checked_unwrap();
-                fetch.table_data = Some(column.get_data_slice().into());
+                Self::set_table(fetch, component_id, table);
             }
         }
     }
@@ -964,12 +970,15 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
         &component_id: &ComponentChangeId,
         table: &'w Table,
     ) {
+        // TODO: 2 options
+        //  - panic if we use Ref<> for a component that does not have change detection
+        //  - or just convert to a normal &T in that case? (return without change ticks?)
         let change_component_id = component_id
             .change_ticks_component
             .expect("change detection is disabled for this component");
         // SAFETY: if change detection is enabled, the change ticks are present in the same table
         let change_column = table.get_column(change_component_id).debug_checked_unwrap();
-        fetch.tick_data = Some(change_column.get_data_slice().into());
+        fetch.table_tick_data = Some(change_column.get_data_slice().into());
 
         let column = table
             .get_column(component_id.component)
@@ -983,17 +992,7 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
         entity: Entity,
         table_row: TableRow,
     ) -> Self::Item<'w> {
-        // SAFETY: the tick data is always present in the same table
-        let table_change_ticks = unsafe { fetch.tick_data.debug_checked_unwrap() };
-        // SAFETY: The caller ensures `table_row` is in range.
-        let component_ticks = unsafe { table_change_ticks.get(table_row.as_usize()) };
-        let ticks = Ticks {
-            added: &component_ticks.deref().added,
-            changed: &component_ticks.deref().changed,
-            this_run: fetch.this_run,
-            last_run: fetch.last_run,
-        };
-        match T::STORAGE_TYPE {
+        let (component, ticks) = match T::STORAGE_TYPE {
             StorageType::Table => {
                 // SAFETY: STORAGE_TYPE = Table
                 let table_components = unsafe { fetch.table_data.debug_checked_unwrap() };
@@ -1001,10 +1000,11 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
                 // SAFETY: The caller ensures `table_row` is in range.
                 let component = unsafe { table_components.get(table_row.as_usize()) };
 
-                Ref {
-                    value: component.deref(),
-                    ticks,
-                }
+                // SAFETY: the tick data is always present in the same table
+                let table_change_ticks = unsafe { fetch.table_tick_data.debug_checked_unwrap() };
+                // SAFETY: The caller ensures `table_row` is in range.
+                let component_ticks = unsafe { table_change_ticks.get(table_row.as_usize()) };
+                (component.deref(), component_ticks.deref())
             }
             StorageType::SparseSet => {
                 // SAFETY: STORAGE_TYPE = SparseSet
@@ -1013,11 +1013,21 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
                 // SAFETY: The caller ensures `entity` is in range.
                 let component = unsafe { component_sparse_set.get(entity).debug_checked_unwrap() };
 
-                Ref {
-                    value: component.deref(),
-                    ticks,
-                }
+                let change_ticks_sparse_set = unsafe { fetch.sparse_tick_data.debug_checked_unwrap() };
+
+                let ticks = unsafe { change_ticks_sparse_set.get(entity).debug_checked_unwrap() };
+                (component.deref(), ticks.deref())
             }
+        };
+        let ticks = Ticks {
+            added: &ticks.added,
+            changed: &ticks.changed,
+            this_run: fetch.this_run,
+            last_run: fetch.last_run,
+        };
+        Ref {
+            value: component,
+            ticks,
         }
     }
 
@@ -1049,6 +1059,8 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
         // SAFETY: we have initialized the component so the component_info exists;
         let component_info = world.components.get_info(component_id).unwrap();
         // TODO: handle cases where the change detection is disabled!
+        //  - do we panic if we call Ref<> for a component that does not have change detection?
+        //  - or do we try to return &C instead?
         let change_component_id = component_info
             .change_detection_id()
             .expect("change detection is disabled for this component");
@@ -1094,8 +1106,12 @@ unsafe impl<'__w, T: Component> ReadOnlyQueryData for Ref<'__w, T> {}
 pub struct WriteFetch<'w, T> {
     // T::STORAGE_TYPE = StorageType::Table
     table_components: Option<ThinSlicePtr<'w, UnsafeCell<T>>>,
+    table_tick_data: Option<ThinSlicePtr<'w, UnsafeCell<ComponentTicks>>>,
     // T::STORAGE_TYPE = StorageType::SparseSet
     sparse_set: Option<&'w ComponentSparseSet>,
+    sparse_tick_data: Option<&'w ComponentSparseSet>,
+    last_run: Tick,
+    this_run: Tick,
 }
 
 impl<T> Clone for crate::query::WriteFetch<'_, T> {
@@ -1111,169 +1127,12 @@ impl<T> Copy for crate::query::WriteFetch<'_, T> {}
 /// `update_component_access` adds a `With` filter for a component.
 /// This is sound because `matches_component_set` returns whether the set contains that component.
 unsafe impl<T: Component> WorldQuery for &mut T {
-    type Item<'w> = &'w mut T;
+    type Item<'w> = T::WriteItem<'w>;
     type Fetch<'w> = crate::query::WriteFetch<'w, T>;
-    type State = ComponentId;
-
-    fn shrink<'wlong: 'wshort, 'wshort>(item: &'wlong mut T) -> &'wshort mut T {
-        item
-    }
-
-    #[inline]
-    unsafe fn init_fetch<'w>(
-        world: UnsafeWorldCell<'w>,
-        &component_id: &ComponentId,
-        _last_run: Tick,
-        _this_run: Tick,
-    ) -> crate::query::WriteFetch<'w, T> {
-        crate::query::WriteFetch {
-            table_components: None,
-            sparse_set: (T::STORAGE_TYPE == StorageType::SparseSet).then(|| {
-                // SAFETY: The underlying type associated with `component_id` is `T`,
-                // which we are allowed to access since we registered it in `update_archetype_component_access`.
-                // Note that we do not actually access any components in this function, we just get a shared
-                // reference to the sparse set, which is used to access the components in `Self::fetch`.
-                unsafe {
-                    world
-                        .storages()
-                        .sparse_sets
-                        .get(component_id)
-                        .debug_checked_unwrap()
-                }
-            }),
-        }
-    }
-
-    const IS_DENSE: bool = {
-        match T::STORAGE_TYPE {
-            StorageType::Table => true,
-            StorageType::SparseSet => false,
-        }
-    };
-
-    #[inline]
-    unsafe fn set_archetype<'w>(
-        fetch: &mut crate::query::WriteFetch<'w, T>,
-        component_id: &ComponentId,
-        _archetype: &'w Archetype,
-        table: &'w Table,
-    ) {
-        if Self::IS_DENSE {
-            // SAFETY: `set_archetype`'s safety rules are a super set of the `set_table`'s ones.
-            unsafe {
-                Self::set_table(fetch, component_id, table);
-            }
-        }
-    }
-
-    #[inline]
-    unsafe fn set_table<'w>(
-        fetch: &mut crate::query::WriteFetch<'w, T>,
-        &component_id: &ComponentId,
-        table: &'w Table,
-    ) {
-        fetch.table_components = Some(
-            table
-                .get_column(component_id)
-                .debug_checked_unwrap()
-                .get_data_slice()
-                .into(),
-        );
-    }
-
-    #[inline(always)]
-    unsafe fn fetch<'w>(
-        fetch: &mut Self::Fetch<'w>,
-        entity: Entity,
-        table_row: TableRow,
-    ) -> Self::Item<'w> {
-        match T::STORAGE_TYPE {
-            StorageType::Table => {
-                // SAFETY: STORAGE_TYPE = Table
-                let table = unsafe { fetch.table_components.debug_checked_unwrap() };
-                // SAFETY: Caller ensures `table_row` is in range.
-                let item = unsafe { table.get(table_row.as_usize()) };
-                item.deref_mut()
-            }
-            StorageType::SparseSet => {
-                // SAFETY: STORAGE_TYPE = SparseSet
-                let sparse_set = unsafe { fetch.sparse_set.debug_checked_unwrap() };
-                // SAFETY: Caller ensures `entity` is in range.
-                let item = unsafe { sparse_set.get(entity).debug_checked_unwrap() };
-                item.assert_unique().deref_mut()
-            }
-        }
-    }
-
-    fn update_component_access(
-        &component_id: &ComponentId,
-        access: &mut FilteredAccess<ComponentId>,
-    ) {
-        assert!(
-            !access.access().has_read(component_id),
-            "&mut {} conflicts with a previous access in this query. Mutable component access must be unique.",
-            std::any::type_name::<T>(),
-        );
-        access.add_write(component_id);
-    }
-
-    fn init_state(world: &mut World) -> ComponentId {
-        // TODO: find something better than a runtime panic..
-        // assert!(!T::CHANGE_DETECTION, "Can fetch &mut T only for components without change detection");
-        world.init_component::<T>()
-    }
-
-    fn get_state(world: &World) -> Option<Self::State> {
-        // assert!(!T::CHANGE_DETECTION, "Can fetch &mut T only for components without change detection");
-        world.component_id::<T>()
-    }
-
-    fn matches_component_set(
-        &state: &ComponentId,
-        set_contains_id: &impl Fn(ComponentId) -> bool,
-    ) -> bool {
-        set_contains_id(state)
-    }
-}
-
-/// SAFETY: `Self` is the same as `Self::ReadOnly`
-unsafe impl<'w, T: Component> QueryData for &'w mut T {
-    type ReadOnly = &'w T;
-}
-
-#[doc(hidden)]
-pub struct MutFetch<'w, T> {
-    // T::STORAGE_TYPE = StorageType::Table
-    table_data: Option<ThinSlicePtr<'w, UnsafeCell<T>>>,
-    // T::STORAGE_TYPE = StorageType::SparseSet
-    sparse_set: Option<&'w ComponentSparseSet>,
-
-    tick_data: Option<ThinSlicePtr<'w, UnsafeCell<ComponentTicks>>>,
-
-    last_run: Tick,
-    this_run: Tick,
-}
-
-impl<T> Clone for MutFetch<'_, T> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<T> Copy for MutFetch<'_, T> {}
-
-/// SAFETY:
-/// `fetch` accesses a single component mutably.
-/// This is sound because `update_component_access` and `update_archetype_component_access` add write access for that component and panic when appropriate.
-/// `update_component_access` adds a `With` filter for a component.
-/// This is sound because `matches_component_set` returns whether the set contains that component.
-unsafe impl<'__w, T: Component> WorldQuery for Mut<'__w, T> {
-    // TODO: figure out how to change the Item type based on T::CHANGE_DETECTION
-    type Item<'w> = Mut<'w, T>;
-    type Fetch<'w> = MutFetch<'w, T>;
     type State = ComponentChangeId;
 
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Mut<'wlong, T>) -> Mut<'wshort, T> {
-        item
+    fn shrink<'wlong: 'wshort, 'wshort>(item: T::WriteItem<'wlong>) -> T::WriteItem<'wshort> {
+        T::shrink(item)
     }
 
     #[inline]
@@ -1282,9 +1141,10 @@ unsafe impl<'__w, T: Component> WorldQuery for Mut<'__w, T> {
         &component_id: &ComponentChangeId,
         last_run: Tick,
         this_run: Tick,
-    ) -> MutFetch<'w, T> {
-        MutFetch {
-            table_data: None,
+    ) -> crate::query::WriteFetch<'w, T> {
+        crate::query::WriteFetch {
+            table_components: None,
+            table_tick_data: None,
             sparse_set: (T::STORAGE_TYPE == StorageType::SparseSet).then(|| {
                 // SAFETY: The underlying type associated with `component_id` is `T`,
                 // which we are allowed to access since we registered it in `update_archetype_component_access`.
@@ -1298,7 +1158,18 @@ unsafe impl<'__w, T: Component> WorldQuery for Mut<'__w, T> {
                         .debug_checked_unwrap()
                 }
             }),
-            tick_data: None,
+            sparse_tick_data: ((T::STORAGE_TYPE == StorageType::SparseSet) && T::CHANGE_DETECTION).then(|| {
+                // SAFETY: if change detection is enabled, the change_ticks_component is guaranteed to exists
+                // and it uses the same storage type as the original component
+                unsafe {
+                    world
+                        .storages()
+                        .sparse_sets
+                        .get(component_id.change_ticks_component.unwrap())
+                        .debug_checked_unwrap()
+                }
+            }),
+            // TODO: remove these from fetch if change detection is disabled?
             last_run,
             this_run,
         }
@@ -1313,44 +1184,41 @@ unsafe impl<'__w, T: Component> WorldQuery for Mut<'__w, T> {
 
     #[inline]
     unsafe fn set_archetype<'w>(
-        fetch: &mut MutFetch<'w, T>,
+        fetch: &mut crate::query::WriteFetch<'w, T>,
         component_id: &ComponentChangeId,
         _archetype: &'w Archetype,
         table: &'w Table,
     ) {
-        let change_component_id = component_id
-            .change_ticks_component
-            .expect("change detection is disabled for this component");
-        // SAFETY: if change detection is enabled, the change ticks are present in the same table
-        let change_column = table.get_column(change_component_id).debug_checked_unwrap();
-        fetch.tick_data = Some(change_column.get_data_slice().into());
         if Self::IS_DENSE {
             // SAFETY: `set_archetype`'s safety rules are a super set of the `set_table`'s ones.
             unsafe {
-                let column = table
-                    .get_column(component_id.component)
-                    .debug_checked_unwrap();
-                fetch.table_data = Some(column.get_data_slice().into());
+                Self::set_table(fetch, component_id, table);
             }
         }
     }
 
     #[inline]
     unsafe fn set_table<'w>(
-        fetch: &mut MutFetch<'w, T>,
+        fetch: &mut crate::query::WriteFetch<'w, T>,
         &component_id: &ComponentChangeId,
         table: &'w Table,
     ) {
-        let change_component_id = component_id
-            .change_ticks_component
-            .expect("change detection is disabled for this component");
-        // SAFETY: if change detection is enabled, the change ticks are present in the same table
-        let change_column = table.get_column(change_component_id).debug_checked_unwrap();
-        fetch.tick_data = Some(change_column.get_data_slice().into());
-        let column = table
-            .get_column(component_id.component)
-            .debug_checked_unwrap();
-        fetch.table_data = Some(column.get_data_slice().into());
+        fetch.table_components = Some(
+            table
+                .get_column(component_id.component)
+                .debug_checked_unwrap()
+                .get_data_slice()
+                .into(),
+        );
+        T::CHANGE_DETECTION.then(|| {
+            fetch.table_tick_data = Some(
+                table
+                    .get_column(component_id.change_ticks_component.unwrap())
+                    .debug_checked_unwrap()
+                    .get_data_slice()
+                    .into(),
+            );
+        });
     }
 
     #[inline(always)]
@@ -1359,41 +1227,49 @@ unsafe impl<'__w, T: Component> WorldQuery for Mut<'__w, T> {
         entity: Entity,
         table_row: TableRow,
     ) -> Self::Item<'w> {
-        // SAFETY: the tick data is always present in the same table
-        let table_change_ticks = unsafe { fetch.tick_data.debug_checked_unwrap() };
-        // SAFETY: The caller ensures `table_row` is in range.
-        let component_ticks = unsafe { table_change_ticks.get(table_row.as_usize()) };
-        let ticks = TicksMut {
-            added: &mut component_ticks.deref_mut().added,
-            changed: &mut component_ticks.deref_mut().changed,
-            this_run: fetch.this_run,
-            last_run: fetch.last_run,
-        };
-        match T::STORAGE_TYPE {
+        // TODO: build Mut or &mut based on T::CHANGE_DETECTION
+        let component = match T::STORAGE_TYPE {
             StorageType::Table => {
                 // SAFETY: STORAGE_TYPE = Table
-                let table_components = unsafe { fetch.table_data.debug_checked_unwrap() };
-
-                // SAFETY: The caller ensures `table_row` is in range.
-                let component = unsafe { table_components.get(table_row.as_usize()) };
-
-                Mut {
-                    value: component.deref_mut(),
-                    ticks,
-                }
+                let table = unsafe { fetch.table_components.debug_checked_unwrap() };
+                // SAFETY: Caller ensures `table_row` is in range.
+                let item = unsafe { table.get(table_row.as_usize()) };
+                item.deref_mut()
             }
             StorageType::SparseSet => {
                 // SAFETY: STORAGE_TYPE = SparseSet
-                let component_sparse_set = unsafe { fetch.sparse_set.debug_checked_unwrap() };
-
-                // SAFETY: The caller ensures `entity` is in range.
-                let component = unsafe { component_sparse_set.get(entity).debug_checked_unwrap() };
-
-                Mut {
-                    value: component.assert_unique().deref_mut(),
-                    ticks,
-                }
+                let sparse_set = unsafe { fetch.sparse_set.debug_checked_unwrap() };
+                // SAFETY: Caller ensures `entity` is in range.
+                let item = unsafe { sparse_set.get(entity).debug_checked_unwrap() };
+                item.assert_unique().deref_mut()
             }
+        };
+        if !T::CHANGE_DETECTION {
+            Self::Item::build(component, None)
+        } else {
+            let ticks = match T::STORAGE_TYPE {
+                StorageType::Table => {
+                    // SAFETY: STORAGE_TYPE = Table
+                    let table = unsafe { fetch.table_tick_data.debug_checked_unwrap() };
+                    // SAFETY: Caller ensures `table_row` is in range.
+                    let item = unsafe { table.get(table_row.as_usize()) };
+                    item.deref_mut()
+                }
+                StorageType::SparseSet => {
+                    // SAFETY: STORAGE_TYPE = SparseSet
+                    let sparse_set = unsafe { fetch.sparse_tick_data.debug_checked_unwrap() };
+                    // SAFETY: Caller ensures `entity` is in range.
+                    let item = unsafe { sparse_set.get(entity).debug_checked_unwrap() };
+                    item.assert_unique().deref_mut()
+                }
+            };
+            let ticks_mut = TicksMut {
+                added: &mut ticks.added,
+                changed: &mut ticks.changed,
+                this_run: fetch.this_run,
+                last_run: fetch.last_run,
+            };
+            Self::Item::build(component, Some(ticks_mut))
         }
     }
 
@@ -1401,69 +1277,95 @@ unsafe impl<'__w, T: Component> WorldQuery for Mut<'__w, T> {
         &component_id: &ComponentChangeId,
         access: &mut FilteredAccess<ComponentId>,
     ) {
-        let change_component_id = component_id
-            .change_ticks_component
-            .expect("change detection is disabled for this component");
         assert!(
             !access.access().has_read(component_id.component),
-            "&mut {} conflicts with a previous access in this query. Mutable component access must be unique.",
-                std::any::type_name::<T>(),
-        );
-        assert!(
-            !access.access().has_read(change_component_id),
             "&mut {} conflicts with a previous access in this query. Mutable component access must be unique.",
             std::any::type_name::<T>(),
         );
         access.add_write(component_id.component);
-        access.add_write(change_component_id);
+        if T::CHANGE_DETECTION {
+            let change_component_id = component_id.change_ticks_component.unwrap();
+            assert!(
+                !access.access().has_read(change_component_id),
+                "&mut {} conflicts with a previous access in this query. Mutable component access must be unique.",
+                std::any::type_name::<T>(),
+            );
+            access.add_write(change_component_id);
+        }
     }
 
     fn init_state(world: &mut World) -> ComponentChangeId {
-        // TODO: is it necessary to call init_component here?
-        //  the components aren't initialized somewhere else before?
         let component_id = world.init_component::<T>();
-        // SAFETY: we have initialized the component so the component_info exists;
-        let component_info = world.components.get_info(component_id).unwrap();
-        // TODO: handle cases where the change detection is disabled!
-        let change_component_id = component_info
-            .change_detection_id()
-            .expect("change detection is disabled for this component");
-        ComponentChangeId {
-            component: component_id,
-            change_ticks_component: Some(change_component_id),
+        if !T::CHANGE_DETECTION {
+            ComponentChangeId {
+                component: component_id,
+                change_ticks_component: None,
+            }
+        } else {
+            // SAFETY: we have initialized the component so the component_info exists;
+            let component_info = world.components.get_info(component_id).unwrap();
+            // TODO: handle cases where the change detection is disabled!
+            // SAFETY: we know that change detection is enabled, so the change detection id is present
+            let change_component_id = component_info
+                .change_detection_id()
+                .unwrap();
+            ComponentChangeId {
+                component: component_id,
+                change_ticks_component: Some(change_component_id),
+            }
         }
     }
 
     fn get_state(world: &World) -> Option<Self::State> {
         let component_id = world.component_id::<T>()?;
-        world.components.get_info(component_id).and_then(|info| {
-            let change_component_id = info
-                .change_detection_id()
-                .expect("change detection is disabled for this component");
+        if !T::CHANGE_DETECTION {
             Some(ComponentChangeId {
                 component: component_id,
-                change_ticks_component: Some(change_component_id),
+                change_ticks_component: None,
             })
-        })
+        } else {
+            world.components.get_info(component_id).and_then(|info| {
+                let change_component_id = info
+                    .change_detection_id()?;
+                Some(ComponentChangeId {
+                    component: component_id,
+                    change_ticks_component: Some(change_component_id),
+                })
+            })
+        }
     }
 
     fn matches_component_set(
         &state: &ComponentChangeId,
         set_contains_id: &impl Fn(ComponentId) -> bool,
     ) -> bool {
-        set_contains_id(state.component)
-            && set_contains_id(
-                state
-                    .change_ticks_component
-                    .expect("change detection is disabled for this component"),
-            )
+        if T::CHANGE_DETECTION {
+            set_contains_id(state.component)
+                && set_contains_id(state.change_ticks_component.unwrap())
+        } else {
+            set_contains_id(state.component)
+        }
     }
 }
 
-/// SAFETY: access of `&T` is a subset of `&mut T`
-unsafe impl<'__w, T: Component> QueryData for Mut<'__w, T> {
-    type ReadOnly = Ref<'__w, T>;
+// TODO: this code makes &T the readonly version of &mut T if change detection is disabled,
+//  otherwise it is Ref<T>.
+//  However I see that plenty of tests function under the assumption that &T if the readonly version of &mut T (not Ref<T>)
+//  so I just left it as is for now
+// /// SAFETY: `Self` is the same as `Self::ReadOnly`
+// unsafe impl<'w, T: Component> QueryData for &'w mut T
+// where <T::WriteItem<'w> as MutFetchItem<'w>>::ReadOnly: ReadOnlyQueryData<State = <Self as WorldQuery>::State>
+// {
+//     type ReadOnly = <T::WriteItem<'w> as MutFetchItem<'w>>::ReadOnly;
+// }
+
+/// SAFETY: `Self` is the same as `Self::ReadOnly`
+unsafe impl<'w, T: Component> QueryData for &'w mut T
+{
+    type ReadOnly = &'w T;
 }
+
+
 
 #[doc(hidden)]
 pub struct OptionFetch<'w, T: WorldQuery> {

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1014,9 +1014,11 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
                 // SAFETY: The caller ensures `entity` is in range.
                 let component = unsafe { component_sparse_set.get(entity).debug_checked_unwrap() };
 
+                // SAFETY: STORAGE_TYPE = SparseSet
                 let change_ticks_sparse_set =
                     unsafe { fetch.sparse_tick_data.debug_checked_unwrap() };
 
+                // SAFETY: The caller ensures `entity` is in range.
                 let ticks = unsafe { change_ticks_sparse_set.get(entity).debug_checked_unwrap() };
                 (component.deref(), ticks.deref())
             }

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1206,10 +1206,13 @@ unsafe impl<T: Component> WorldQuery for &mut T {
     }
 
     fn init_state(world: &mut World) -> ComponentId {
+        // TODO: find something better than a runtime panic..
+        assert!(!T::CHANGE_DETECTION, "Can fetch &mut T only for components without change detection");
         world.init_component::<T>()
     }
 
     fn get_state(world: &World) -> Option<Self::State> {
+        assert!(!T::CHANGE_DETECTION, "Can fetch &mut T only for components without change detection");
         world.component_id::<T>()
     }
 

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -941,7 +941,6 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
         // SAFETY: if change detection is enabled, the change ticks are present in the same table
         let change_column = table.get_column(component_id.change_ticks_component).debug_checked_unwrap();
         fetch.tick_data = Some(change_column.get_data_slice().into());
-        // Self::set_tick_data(fetch, component_id.change_ticks_component, table);
         if Self::IS_DENSE {
             // SAFETY: `set_archetype`'s safety rules are a super set of the `set_table`'s ones.
             unsafe {
@@ -960,7 +959,7 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
         // SAFETY: if change detection is enabled, the change ticks are present in the same table
         let change_column = table.get_column(component_id.change_ticks_component).debug_checked_unwrap();
         fetch.tick_data = Some(change_column.get_data_slice().into());
-        
+
         let column = table.get_column(component_id.component).debug_checked_unwrap();
         fetch.table_data = Some(column.get_data_slice().into());
     }
@@ -1062,13 +1061,6 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
     }
 }
 
-impl<'w, T: Component> Ref<'w, T> {
-    unsafe fn set_tick_data(fetch: &mut RefFetch<'w, T>, change_component_id: ComponentId, table: &'w Table) {
-        // SAFETY: if change detection is enabled, the change ticks are present in the same table
-        let change_column = table.get_column(change_component_id).debug_checked_unwrap();
-        fetch.tick_data = Some(change_column.get_data_slice().into());
-    }
-}
 
 /// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl<'__w, T: Component> QueryData for Ref<'__w, T> {

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -938,7 +938,10 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
         _archetype: &'w Archetype,
         table: &'w Table,
     ) {
-        Self::set_tick_data(fetch, component_id.change_ticks_component, table);
+        // SAFETY: if change detection is enabled, the change ticks are present in the same table
+        let change_column = table.get_column(component_id.change_ticks_component).debug_checked_unwrap();
+        fetch.tick_data = Some(change_column.get_data_slice().into());
+        // Self::set_tick_data(fetch, component_id.change_ticks_component, table);
         if Self::IS_DENSE {
             // SAFETY: `set_archetype`'s safety rules are a super set of the `set_table`'s ones.
             unsafe {
@@ -954,7 +957,10 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
         &component_id: &ComponentChangeId,
         table: &'w Table,
     ) {
-        Self::set_tick_data(fetch, component_id.change_ticks_component, table);
+        // SAFETY: if change detection is enabled, the change ticks are present in the same table
+        let change_column = table.get_column(component_id.change_ticks_component).debug_checked_unwrap();
+        fetch.tick_data = Some(change_column.get_data_slice().into());
+        
         let column = table.get_column(component_id.component).debug_checked_unwrap();
         fetch.table_data = Some(column.get_data_slice().into());
     }

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1199,7 +1199,7 @@ unsafe impl<T: Component> WorldQuery for &mut T {
     ) {
         assert!(
             !access.access().has_read(component_id),
-            "&{} conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",
+            "&mut {} conflicts with a previous access in this query. Mutable component access must be unique.",
             std::any::type_name::<T>(),
         );
         access.add_write(component_id);
@@ -1207,12 +1207,12 @@ unsafe impl<T: Component> WorldQuery for &mut T {
 
     fn init_state(world: &mut World) -> ComponentId {
         // TODO: find something better than a runtime panic..
-        assert!(!T::CHANGE_DETECTION, "Can fetch &mut T only for components without change detection");
+        // assert!(!T::CHANGE_DETECTION, "Can fetch &mut T only for components without change detection");
         world.init_component::<T>()
     }
 
     fn get_state(world: &World) -> Option<Self::State> {
-        assert!(!T::CHANGE_DETECTION, "Can fetch &mut T only for components without change detection");
+        // assert!(!T::CHANGE_DETECTION, "Can fetch &mut T only for components without change detection");
         world.component_id::<T>()
     }
 

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -671,31 +671,30 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
         entity: Entity,
         table_row: TableRow,
     ) -> Self::Item<'w> {
-        if T::CHANGE_DETECTION {
-            match T::STORAGE_TYPE {
-                StorageType::Table => {
-                    // SAFETY: STORAGE_TYPE = Table
-                    let table = unsafe { fetch.table_ticks.debug_checked_unwrap() };
-                    // SAFETY: The caller ensures `table_row` is in range.
-                    let tick = unsafe { table.get(table_row.as_usize()) };
-
-                    tick.deref()
-                        .added
-                        .is_newer_than(fetch.last_run, fetch.this_run)
-                }
-                StorageType::SparseSet => {
-                    // SAFETY: STORAGE_TYPE = SparseSet
-                    let sparse_set = unsafe { fetch.sparse_ticks.debug_checked_unwrap() };
-                    // SAFETY: Caller ensures `entity` is in range.
-                    let item = unsafe { sparse_set.get(entity).debug_checked_unwrap() };
-                    item.deref::<ComponentTicks>()
-                        .added
-                        .is_newer_than(fetch.last_run, fetch.this_run)
-                }
-            }
-        } else {
+        if !T::CHANGE_DETECTION {
             // if change detection is disabled, match all entities with this component
             return true;
+        }
+        match T::STORAGE_TYPE {
+            StorageType::Table => {
+                // SAFETY: STORAGE_TYPE = Table
+                let table = unsafe { fetch.table_ticks.debug_checked_unwrap() };
+                // SAFETY: The caller ensures `table_row` is in range.
+                let tick = unsafe { table.get(table_row.as_usize()) };
+
+                tick.deref()
+                    .added
+                    .is_newer_than(fetch.last_run, fetch.this_run)
+            }
+            StorageType::SparseSet => {
+                // SAFETY: STORAGE_TYPE = SparseSet
+                let sparse_set = unsafe { fetch.sparse_ticks.debug_checked_unwrap() };
+                // SAFETY: Caller ensures `entity` is in range.
+                let item = unsafe { sparse_set.get(entity).debug_checked_unwrap() };
+                item.deref::<ComponentTicks>()
+                    .added
+                    .is_newer_than(fetch.last_run, fetch.this_run)
+            }
         }
     }
 
@@ -719,8 +718,7 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
             // SAFETY: we have initialized the component so the component_info exists;
             let component_info = world.components.get_info(component_id).unwrap();
             // SAFETY: we know that change detection is enabled, so the change detection id is present
-            let change_component_id = component_info.change_detection_id().unwrap();
-            change_component_id
+            component_info.change_detection_id().unwrap()
         })
     }
 
@@ -923,31 +921,30 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
         entity: Entity,
         table_row: TableRow,
     ) -> Self::Item<'w> {
-        if T::CHANGE_DETECTION {
-            match T::STORAGE_TYPE {
-                StorageType::Table => {
-                    // SAFETY: STORAGE_TYPE = Table
-                    let table = unsafe { fetch.table_ticks.debug_checked_unwrap() };
-                    // SAFETY: The caller ensures `table_row` is in range.
-                    let tick = unsafe { table.get(table_row.as_usize()) };
-
-                    tick.deref()
-                        .changed
-                        .is_newer_than(fetch.last_run, fetch.this_run)
-                }
-                StorageType::SparseSet => {
-                    // SAFETY: STORAGE_TYPE = SparseSet
-                    let sparse_set = unsafe { fetch.sparse_ticks.debug_checked_unwrap() };
-                    // SAFETY: Caller ensures `entity` is in range.
-                    let item = unsafe { sparse_set.get(entity).debug_checked_unwrap() };
-                    item.deref::<ComponentTicks>()
-                        .changed
-                        .is_newer_than(fetch.last_run, fetch.this_run)
-                }
-            }
-        } else {
+        if !T::CHANGE_DETECTION {
             // if change detection is disabled, match all entities with this component
             return true;
+        }
+        match T::STORAGE_TYPE {
+            StorageType::Table => {
+                // SAFETY: STORAGE_TYPE = Table
+                let table = unsafe { fetch.table_ticks.debug_checked_unwrap() };
+                // SAFETY: The caller ensures `table_row` is in range.
+                let tick = unsafe { table.get(table_row.as_usize()) };
+
+                tick.deref()
+                    .changed
+                    .is_newer_than(fetch.last_run, fetch.this_run)
+            }
+            StorageType::SparseSet => {
+                // SAFETY: STORAGE_TYPE = SparseSet
+                let sparse_set = unsafe { fetch.sparse_ticks.debug_checked_unwrap() };
+                // SAFETY: Caller ensures `entity` is in range.
+                let item = unsafe { sparse_set.get(entity).debug_checked_unwrap() };
+                item.deref::<ComponentTicks>()
+                    .changed
+                    .is_newer_than(fetch.last_run, fetch.this_run)
+            }
         }
     }
 
@@ -973,8 +970,7 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
             // SAFETY: we have initialized the component so the component_info exists;
             let component_info = world.components.get_info(component_id).unwrap();
             // SAFETY: we know that change detection is enabled, so the change detection id is present
-            let change_component_id = component_info.change_detection_id().unwrap();
-            change_component_id
+            component_info.change_detection_id().unwrap()
         })
     }
 

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -603,7 +603,7 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
 
     #[inline]
     unsafe fn init_fetch<'w>(
-        world: UnsafeWorldCell<'w>,
+        _world: UnsafeWorldCell<'w>,
         &id: &ComponentId,
         last_run: Tick,
         this_run: Tick,

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -853,13 +853,17 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
             panic!("$state_name<{}> conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",std::any::type_name::<T>());
         }
         access.add_read(id);
+        // TODO: should we also restrict access to the actual component? i'm confused
+        //  i think this access is mostly just to find which archetypes match
     }
 
     fn init_state(world: &mut World) -> ComponentId {
         let component_id = world.init_component::<T>();
-        // TODO: deal with the change ticks not existing
         let component_info = world.components.get_info(component_id).unwrap();
-        let change_component_id = component_info.change_detection_id().unwrap();
+        // TODO: is panicking the best solution here?
+        let change_component_id = component_info.change_detection_id().expect(
+            "Component change detection is not enabled for this component!"
+        );
         change_component_id
     }
 

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -1,3 +1,4 @@
+use crate::component::ComponentTicks;
 use crate::{
     archetype::Archetype,
     component::{Component, ComponentId, StorageType, Tick},
@@ -9,7 +10,6 @@ use crate::{
 use bevy_ptr::{ThinSlicePtr, UnsafeCellDeref};
 use bevy_utils::all_tuples;
 use std::{cell::UnsafeCell, marker::PhantomData};
-use crate::component::ComponentTicks;
 
 /// Types that filter the results of a [`Query`].
 ///
@@ -653,7 +653,9 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
         let table = unsafe { fetch.table_ticks.debug_checked_unwrap() };
         // SAFETY: The caller ensures `table_row` is in range.
         let tick = unsafe { table.get(table_row.as_usize()) };
-        tick.deref().added.is_newer_than(fetch.last_run, fetch.this_run)
+        tick.deref()
+            .added
+            .is_newer_than(fetch.last_run, fetch.this_run)
     }
 
     #[inline]
@@ -674,9 +676,10 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
 
     fn get_state(world: &World) -> Option<ComponentId> {
         let component_id = world.component_id::<T>()?;
-        world.components.get_info(component_id).and_then(|info| {
-            info.change_detection_id()
-        })
+        world
+            .components
+            .get_info(component_id)
+            .and_then(|info| info.change_detection_id())
     }
 
     fn matches_component_set(
@@ -844,7 +847,9 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
         let table = unsafe { fetch.table_ticks.debug_checked_unwrap() };
         // SAFETY: The caller ensures `table_row` is in range.
         let tick = unsafe { table.get(table_row.as_usize()) };
-        tick.deref().changed.is_newer_than(fetch.last_run, fetch.this_run)
+        tick.deref()
+            .changed
+            .is_newer_than(fetch.last_run, fetch.this_run)
     }
 
     #[inline]
@@ -861,17 +866,18 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
         let component_id = world.init_component::<T>();
         let component_info = world.components.get_info(component_id).unwrap();
         // TODO: is panicking the best solution here?
-        let change_component_id = component_info.change_detection_id().expect(
-            "Component change detection is not enabled for this component!"
-        );
+        let change_component_id = component_info
+            .change_detection_id()
+            .expect("Component change detection is not enabled for this component!");
         change_component_id
     }
 
     fn get_state(world: &World) -> Option<ComponentId> {
         let component_id = world.component_id::<T>()?;
-        world.components.get_info(component_id).and_then(|info| {
-            info.change_detection_id()
-        })
+        world
+            .components
+            .get_info(component_id)
+            .and_then(|info| info.change_detection_id())
     }
 
     fn matches_component_set(

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -10,6 +10,7 @@ use crate::{
 use bevy_ptr::{ThinSlicePtr, UnsafeCellDeref};
 use bevy_utils::all_tuples;
 use std::{cell::UnsafeCell, marker::PhantomData};
+use crate::storage::ComponentSparseSet;
 
 /// Types that filter the results of a [`Query`].
 ///
@@ -583,6 +584,7 @@ pub struct Added<T>(PhantomData<T>);
 #[derive(Clone)]
 pub struct AddedFetch<'w> {
     table_ticks: Option<ThinSlicePtr<'w, UnsafeCell<ComponentTicks>>>,
+    sparse_ticks: Option<&'w ComponentSparseSet>,
     last_run: Tick,
     this_run: Tick,
 }
@@ -595,7 +597,7 @@ pub struct AddedFetch<'w> {
 unsafe impl<T: Component> WorldQuery for Added<T> {
     type Item<'w> = bool;
     type Fetch<'w> = AddedFetch<'w>;
-    type State = ComponentId;
+    type State = Option<ComponentId>;
 
     fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
         item
@@ -603,13 +605,23 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
 
     #[inline]
     unsafe fn init_fetch<'w>(
-        _world: UnsafeWorldCell<'w>,
-        &id: &ComponentId,
+        world: UnsafeWorldCell<'w>,
+        &id: &Option<ComponentId>,
         last_run: Tick,
         this_run: Tick,
     ) -> Self::Fetch<'w> {
         Self::Fetch::<'w> {
             table_ticks: None,
+            sparse_ticks: ((T::STORAGE_TYPE == StorageType::SparseSet) && T::CHANGE_DETECTION).then(|| {
+                // SAFETY: change detection is enabled so the component exists
+                unsafe {
+                    world
+                        .storages()
+                        .sparse_sets
+                        .get(id.unwrap())
+                        .debug_checked_unwrap()
+                }
+            }),
             last_run,
             this_run,
         }
@@ -625,68 +637,104 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
     #[inline]
     unsafe fn set_archetype<'w>(
         fetch: &mut Self::Fetch<'w>,
-        component_id: &ComponentId,
+        component_id: &Option<ComponentId>,
         _archetype: &'w Archetype,
         table: &'w Table,
     ) {
-        Self::set_table(fetch, component_id, table);
+        if Self::IS_DENSE {
+            // SAFETY: `set_archetype`'s safety rules are a super set of the `set_table`'s ones.
+            unsafe {
+                Self::set_table(fetch, component_id, table);
+            }
+        }
     }
 
     #[inline]
     unsafe fn set_table<'w>(
         fetch: &mut Self::Fetch<'w>,
-        &component_id: &ComponentId,
+        &component_id: &Option<ComponentId>,
         table: &'w Table,
     ) {
-        // TODO: SAFETY:
-        let column = table.get_column(component_id).debug_checked_unwrap();
-        fetch.table_ticks = Some(column.get_data_slice().into());
+        if T::CHANGE_DETECTION {
+            // TODO: safety docs
+            let column = table.get_column(component_id.unwrap()).debug_checked_unwrap();
+            fetch.table_ticks = Some(column.get_data_slice().into());
+        }
     }
 
     #[inline(always)]
     unsafe fn fetch<'w>(
         fetch: &mut Self::Fetch<'w>,
-        _entity: Entity,
+        entity: Entity,
         table_row: TableRow,
     ) -> Self::Item<'w> {
-        // TODO: safety
-        let table = unsafe { fetch.table_ticks.debug_checked_unwrap() };
-        // SAFETY: The caller ensures `table_row` is in range.
-        let tick = unsafe { table.get(table_row.as_usize()) };
-        tick.deref()
-            .added
-            .is_newer_than(fetch.last_run, fetch.this_run)
+        if T::CHANGE_DETECTION {
+            match T::STORAGE_TYPE {
+                StorageType::Table => {
+                    // SAFETY: STORAGE_TYPE = Table
+                    let table = unsafe { fetch.table_ticks.debug_checked_unwrap() };
+                    // SAFETY: The caller ensures `table_row` is in range.
+                    let tick = unsafe { table.get(table_row.as_usize()) };
+
+                    tick.deref().added.is_newer_than(fetch.last_run, fetch.this_run)
+                }
+                StorageType::SparseSet => {
+                    // SAFETY: STORAGE_TYPE = SparseSet
+                    let sparse_set = unsafe { fetch.sparse_ticks.debug_checked_unwrap() };
+                    // SAFETY: Caller ensures `entity` is in range.
+                    let item = unsafe { sparse_set.get(entity).debug_checked_unwrap() };
+                    item.deref::<ComponentTicks>().added.is_newer_than(fetch.last_run, fetch.this_run)
+                }
+            }
+        } else {
+            // if change detection is disabled, match all entities with this component
+            return true
+        }
     }
 
     #[inline]
-    fn update_component_access(&id: &ComponentId, access: &mut FilteredAccess<ComponentId>) {
-        if access.access().has_write(id) {
-            panic!("$state_name<{}> conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",std::any::type_name::<T>());
+    fn update_component_access(&id: &Option<ComponentId>, access: &mut FilteredAccess<ComponentId>) {
+        if T::CHANGE_DETECTION {
+            let id = id.unwrap();
+            if access.access().has_write(id) {
+                panic!("$state_name<{}> conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.", std::any::type_name::<T>());
+            }
+            access.add_read(id);
         }
-        access.add_read(id);
     }
 
-    fn init_state(world: &mut World) -> ComponentId {
-        let component_id = world.init_component::<T>();
-        // TODO: deal with the change ticks not existing
-        let component_info = world.components.get_info(component_id).unwrap();
-        let change_component_id = component_info.change_detection_id().unwrap();
-        change_component_id
+    fn init_state(world: &mut World) -> Option<ComponentId> {
+        T::CHANGE_DETECTION.then(|| {
+            let component_id = world.init_component::<T>();
+            // SAFETY: we have initialized the component so the component_info exists;
+            let component_info = world.components.get_info(component_id).unwrap();
+            // SAFETY: we know that change detection is enabled, so the change detection id is present
+            let change_component_id = component_info
+                .change_detection_id()
+                .unwrap();
+            change_component_id
+        })
     }
 
-    fn get_state(world: &World) -> Option<ComponentId> {
+    fn get_state(world: &World) -> Option<Option<ComponentId>> {
+        if !T::CHANGE_DETECTION {
+            return None
+        }
         let component_id = world.component_id::<T>()?;
-        world
+        Some(world
             .components
             .get_info(component_id)
-            .and_then(|info| info.change_detection_id())
+            .and_then(|info| info.change_detection_id()))
     }
 
     fn matches_component_set(
-        &id: &ComponentId,
+        &id: &Option<ComponentId>,
         set_contains_id: &impl Fn(ComponentId) -> bool,
     ) -> bool {
-        set_contains_id(id)
+        if !T::CHANGE_DETECTION {
+            return true
+        }
+        set_contains_id(id.unwrap())
     }
 }
 
@@ -778,6 +826,7 @@ pub struct Changed<T>(PhantomData<T>);
 #[derive(Clone)]
 pub struct ChangedFetch<'w> {
     table_ticks: Option<ThinSlicePtr<'w, UnsafeCell<ComponentTicks>>>,
+    sparse_ticks: Option<&'w ComponentSparseSet>,
     last_run: Tick,
     this_run: Tick,
 }
@@ -790,7 +839,7 @@ pub struct ChangedFetch<'w> {
 unsafe impl<T: Component> WorldQuery for Changed<T> {
     type Item<'w> = bool;
     type Fetch<'w> = ChangedFetch<'w>;
-    type State = ComponentId;
+    type State = Option<ComponentId>;
 
     fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
         item
@@ -799,12 +848,22 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
     #[inline]
     unsafe fn init_fetch<'w>(
         world: UnsafeWorldCell<'w>,
-        &id: &ComponentId,
+        &id: &Option<ComponentId>,
         last_run: Tick,
         this_run: Tick,
     ) -> Self::Fetch<'w> {
         Self::Fetch::<'w> {
             table_ticks: None,
+            sparse_ticks: ((T::STORAGE_TYPE == StorageType::SparseSet) && T::CHANGE_DETECTION).then(|| {
+                // SAFETY: change detection is enabled so the component exists
+                unsafe {
+                    world
+                        .storages()
+                        .sparse_sets
+                        .get(id.unwrap())
+                        .debug_checked_unwrap()
+                }
+            }),
             last_run,
             this_run,
         }
@@ -820,21 +879,29 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
     #[inline]
     unsafe fn set_archetype<'w>(
         fetch: &mut Self::Fetch<'w>,
-        component_id: &ComponentId,
+        component_id: &Option<ComponentId>,
         _archetype: &'w Archetype,
         table: &'w Table,
     ) {
-        Self::set_table(fetch, component_id, table);
+        if Self::IS_DENSE {
+            // SAFETY: `set_archetype`'s safety rules are a super set of the `set_table`'s ones.
+            unsafe {
+                Self::set_table(fetch, component_id, table);
+            }
+        }
     }
 
     #[inline]
     unsafe fn set_table<'w>(
         fetch: &mut Self::Fetch<'w>,
-        &component_id: &ComponentId,
+        &component_id: &Option<ComponentId>,
         table: &'w Table,
     ) {
-        let column = table.get_column(component_id).debug_checked_unwrap();
-        fetch.table_ticks = Some(column.get_data_slice().into());
+        if T::CHANGE_DETECTION {
+            // TODO: safety docs
+            let column = table.get_column(component_id.unwrap()).debug_checked_unwrap();
+            fetch.table_ticks = Some(column.get_data_slice().into());
+        }
     }
 
     #[inline(always)]
@@ -843,48 +910,75 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
         entity: Entity,
         table_row: TableRow,
     ) -> Self::Item<'w> {
-        // TODO: safety
-        let table = unsafe { fetch.table_ticks.debug_checked_unwrap() };
-        // SAFETY: The caller ensures `table_row` is in range.
-        let tick = unsafe { table.get(table_row.as_usize()) };
-        tick.deref()
-            .changed
-            .is_newer_than(fetch.last_run, fetch.this_run)
+        if T::CHANGE_DETECTION {
+            match T::STORAGE_TYPE {
+                StorageType::Table => {
+                    // SAFETY: STORAGE_TYPE = Table
+                    let table = unsafe { fetch.table_ticks.debug_checked_unwrap() };
+                    // SAFETY: The caller ensures `table_row` is in range.
+                    let tick = unsafe { table.get(table_row.as_usize()) };
+
+                    tick.deref().changed.is_newer_than(fetch.last_run, fetch.this_run)
+                }
+                StorageType::SparseSet => {
+                    // SAFETY: STORAGE_TYPE = SparseSet
+                    let sparse_set = unsafe { fetch.sparse_ticks.debug_checked_unwrap() };
+                    // SAFETY: Caller ensures `entity` is in range.
+                    let item = unsafe { sparse_set.get(entity).debug_checked_unwrap() };
+                    item.deref::<ComponentTicks>().changed.is_newer_than(fetch.last_run, fetch.this_run)
+                }
+            }
+        } else {
+            // if change detection is disabled, match all entities with this component
+            return true
+        }
     }
 
     #[inline]
-    fn update_component_access(&id: &ComponentId, access: &mut FilteredAccess<ComponentId>) {
-        if access.access().has_write(id) {
-            panic!("$state_name<{}> conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",std::any::type_name::<T>());
+    fn update_component_access(&id: &Option<ComponentId>, access: &mut FilteredAccess<ComponentId>) {
+        if T::CHANGE_DETECTION {
+            let id = id.unwrap();
+            if access.access().has_write(id) {
+                panic!("$state_name<{}> conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.", std::any::type_name::<T>());
+            }
+            access.add_read(id);
         }
-        access.add_read(id);
         // TODO: should we also restrict access to the actual component? i'm confused
         //  i think this access is mostly just to find which archetypes match
     }
 
-    fn init_state(world: &mut World) -> ComponentId {
-        let component_id = world.init_component::<T>();
-        let component_info = world.components.get_info(component_id).unwrap();
-        // TODO: is panicking the best solution here?
-        let change_component_id = component_info
-            .change_detection_id()
-            .expect("Component change detection is not enabled for this component!");
-        change_component_id
+    fn init_state(world: &mut World) -> Option<ComponentId> {
+        T::CHANGE_DETECTION.then(|| {
+            let component_id = world.init_component::<T>();
+            // SAFETY: we have initialized the component so the component_info exists;
+            let component_info = world.components.get_info(component_id).unwrap();
+            // SAFETY: we know that change detection is enabled, so the change detection id is present
+            let change_component_id = component_info
+                .change_detection_id()
+                .unwrap();
+            change_component_id
+        })
     }
 
-    fn get_state(world: &World) -> Option<ComponentId> {
+    fn get_state(world: &World) -> Option<Option<ComponentId>> {
+        if !T::CHANGE_DETECTION {
+            return None
+        }
         let component_id = world.component_id::<T>()?;
-        world
+        Some(world
             .components
             .get_info(component_id)
-            .and_then(|info| info.change_detection_id())
+            .and_then(|info| info.change_detection_id()))
     }
 
     fn matches_component_set(
-        &id: &ComponentId,
+        &id: &Option<ComponentId>,
         set_contains_id: &impl Fn(ComponentId) -> bool,
     ) -> bool {
-        set_contains_id(id)
+        if !T::CHANGE_DETECTION {
+            return true
+        }
+        set_contains_id(id.unwrap())
     }
 }
 

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -78,6 +78,7 @@ mod tests {
     use crate::{self as bevy_ecs, component::Component, world::World};
     use std::any::type_name;
     use std::collections::HashSet;
+    use crate::change_detection::Mut;
 
     #[derive(Component, Debug, Hash, Eq, PartialEq, Clone, Copy)]
     struct A(usize);
@@ -347,7 +348,7 @@ mod tests {
             .collect::<HashSet<_>>()
         );
 
-        let mut query = world.query_filtered::<&mut A, Without<B>>();
+        let mut query = world.query_filtered::<Mut<A>, Without<B>>();
         let mut combinations = query.iter_combinations_mut(&mut world);
         while let Some([mut a, mut b, mut c]) = combinations.fetch_next() {
             a.0 += 10;
@@ -395,7 +396,7 @@ mod tests {
 
         let mut query_changed = world.query_filtered::<&A, Changed<A>>();
 
-        let mut query = world.query_filtered::<&mut A, With<B>>();
+        let mut query = world.query_filtered::<Mut<A>, With<B>>();
         let mut combinations = query.iter_combinations_mut(&mut world);
         while let Some([mut a, mut b, mut c]) = combinations.fetch_next() {
             a.0 += 10;

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -783,13 +783,13 @@ mod tests {
         let mut world = World::new();
         world.spawn((A(1), B(1)));
 
-        fn propagate_system(mut query: Query<(&A, &mut B), Changed<A>>) {
+        fn propagate_system(mut query: Query<(&A, Mut<B>), Changed<A>>) {
             query.par_iter_mut().for_each(|(a, mut b)| {
                 b.0 = a.0;
             });
         }
 
-        fn modify_system(mut query: Query<&mut A>) {
+        fn modify_system(mut query: Query<Mut<A>>) {
             for mut a in &mut query {
                 a.0 = 2;
             }

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -71,6 +71,7 @@ impl<T> DebugCheckedUnwrap for Option<T> {
 mod tests {
     use bevy_ecs_macros::{QueryData, QueryFilter};
 
+    use crate::change_detection::Mut;
     use crate::prelude::{AnyOf, Changed, Entity, Or, QueryState, With, Without};
     use crate::query::{ArchetypeFilter, Has, QueryCombinationIter, ReadOnlyQueryData};
     use crate::schedule::{IntoSystemConfigs, Schedule};
@@ -78,7 +79,6 @@ mod tests {
     use crate::{self as bevy_ecs, component::Component, world::World};
     use std::any::type_name;
     use std::collections::HashSet;
-    use crate::change_detection::Mut;
 
     #[derive(Component, Debug, Hash, Eq, PartialEq, Clone, Copy)]
     struct A(usize);

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -71,7 +71,6 @@ impl<T> DebugCheckedUnwrap for Option<T> {
 mod tests {
     use bevy_ecs_macros::{QueryData, QueryFilter};
 
-    use crate::change_detection::Mut;
     use crate::prelude::{AnyOf, Changed, Entity, Or, QueryState, With, Without};
     use crate::query::{ArchetypeFilter, Has, QueryCombinationIter, ReadOnlyQueryData};
     use crate::schedule::{IntoSystemConfigs, Schedule};
@@ -348,7 +347,7 @@ mod tests {
             .collect::<HashSet<_>>()
         );
 
-        let mut query = world.query_filtered::<Mut<A>, Without<B>>();
+        let mut query = world.query_filtered::<&mut A, Without<B>>();
         let mut combinations = query.iter_combinations_mut(&mut world);
         while let Some([mut a, mut b, mut c]) = combinations.fetch_next() {
             a.0 += 10;
@@ -396,7 +395,7 @@ mod tests {
 
         let mut query_changed = world.query_filtered::<&A, Changed<A>>();
 
-        let mut query = world.query_filtered::<Mut<A>, With<B>>();
+        let mut query = world.query_filtered::<&mut A, With<B>>();
         let mut combinations = query.iter_combinations_mut(&mut world);
         while let Some([mut a, mut b, mut c]) = combinations.fetch_next() {
             a.0 += 10;
@@ -783,13 +782,13 @@ mod tests {
         let mut world = World::new();
         world.spawn((A(1), B(1)));
 
-        fn propagate_system(mut query: Query<(&A, Mut<B>), Changed<A>>) {
+        fn propagate_system(mut query: Query<(&A, &mut B), Changed<A>>) {
             query.par_iter_mut().for_each(|(a, mut b)| {
                 b.0 = a.0;
             });
         }
 
-        fn modify_system(mut query: Query<Mut<A>>) {
+        fn modify_system(mut query: Query<&mut A>) {
             for mut a in &mut query {
                 a.0 = 2;
             }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1702,8 +1702,8 @@ mod tests {
         let q = world.query::<&mut A>();
         let _ = q.transmute::<&A>(&world);
 
-        let q = world.query::<Mut<A>>();
-        let _ = q.transmute::<Ref<A>>(&world);
+        // let q = world.query::<&mut A>();
+        // let _ = q.transmute::<Ref<A>>(&world);
     }
 
     #[test]
@@ -1825,8 +1825,7 @@ mod tests {
         let mut detection_query = QueryState::<(Entity, Ref<A>)>::new(&mut world)
             .transmute_filtered::<Entity, Changed<A>>(&world);
 
-        // need to use Mut<A> to update the change detection ticks!
-        let mut change_query = QueryState::<Mut<A>>::new(&mut world);
+        let mut change_query = QueryState::<&mut A>::new(&mut world);
         assert_eq!(entity_a, detection_query.single(&world));
 
         world.clear_trackers();

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -1,11 +1,11 @@
 use crate::{
-    component::{ComponentId, ComponentInfo, ComponentTicks, Tick, TickCells},
+    component::{ComponentId, ComponentInfo},
     entity::Entity,
     storage::{Column, TableRow},
 };
 use bevy_ptr::{OwningPtr, Ptr};
 use nonmax::NonMaxUsize;
-use std::{cell::UnsafeCell, hash::Hash, marker::PhantomData};
+use std::{hash::Hash, marker::PhantomData};
 
 type EntityIndex = u32;
 
@@ -550,12 +550,6 @@ impl SparseSets {
     pub(crate) fn clear_entities(&mut self) {
         for set in self.sets.values_mut() {
             set.clear();
-        }
-    }
-
-    pub(crate) fn check_change_ticks(&mut self, change_tick: Tick) {
-        for set in self.sets.values_mut() {
-            set.check_change_ticks(change_tick);
         }
     }
 }

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -262,6 +262,10 @@ impl ComponentSparseSet {
             false
         }
     }
+
+    pub(crate) fn get_dense(&self) -> &Column {
+        &self.dense
+    }
 }
 
 /// A data structure that blends dense and sparse storage

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -164,11 +164,7 @@ impl ComponentSparseSet {
     /// # Safety
     /// The `value` pointer must point to a valid address that matches the [`Layout`](std::alloc::Layout)
     /// inside the [`ComponentInfo`] given when constructing this sparse set.
-    pub(crate) unsafe fn insert(
-        &mut self,
-        entity: Entity,
-        value: OwningPtr<'_>,
-    ) {
+    pub(crate) unsafe fn insert(&mut self, entity: Entity, value: OwningPtr<'_>) {
         if let Some(&dense_index) = self.sparse.get(entity.index()) {
             #[cfg(debug_assertions)]
             assert_eq!(entity, self.entities[dense_index.as_usize()]);

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -284,7 +284,7 @@ impl ComponentSparseSet {
             self.entities.swap_remove(dense_index.as_usize());
             let is_last = dense_index.as_usize() == self.dense.len() - 1;
             // SAFETY: dense_index was just removed from `sparse`, which ensures that it is valid
-            let (value, _) = unsafe { self.dense.swap_remove_and_forget_unchecked(dense_index) };
+            let value = unsafe { self.dense.swap_remove_and_forget_unchecked(dense_index) };
             if !is_last {
                 let swapped_entity = self.entities[dense_index.as_usize()];
                 #[cfg(not(debug_assertions))]

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -1,10 +1,10 @@
 use crate::{
-    component::{ComponentId, ComponentInfo, ComponentTicks, Components, Tick, TickCells},
+    component::{ComponentId, ComponentInfo, Components, Tick},
     entity::Entity,
     query::DebugCheckedUnwrap,
     storage::{blob_vec::BlobVec, ImmutableSparseSet, SparseSet},
 };
-use bevy_ptr::{OwningPtr, Ptr, PtrMut, UnsafeCellDeref};
+use bevy_ptr::{OwningPtr, Ptr, PtrMut};
 use bevy_utils::HashMap;
 use std::alloc::Layout;
 use std::{
@@ -301,7 +301,7 @@ impl Column {
     ///
     /// Returns `None` if `row` is out of bounds.
     #[inline]
-    pub fn get(&self, row: TableRow) -> Option<(Ptr<'_>)> {
+    pub fn get(&self, row: TableRow) -> Option<Ptr<'_>> {
         (row.as_usize() < self.data.len())
             // SAFETY: The row is length checked before fetching the pointer. This is being
             // accessed through a read-only reference to the column.

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -175,7 +175,7 @@ impl Column {
     /// # Safety
     /// Assumes data has already been allocated for the given row.
     #[inline]
-    pub(crate) unsafe fn initialize(&mut self, row: TableRow, data: OwningPtr<'_>, tick: Tick) {
+    pub(crate) unsafe fn initialize(&mut self, row: TableRow, data: OwningPtr<'_>) {
         debug_assert!(row.as_usize() < self.len());
         self.data.initialize_unchecked(row.as_usize(), data);
     }
@@ -186,7 +186,7 @@ impl Column {
     /// # Safety
     /// Assumes data has already been allocated for the given row.
     #[inline]
-    pub(crate) unsafe fn replace(&mut self, row: TableRow, data: OwningPtr<'_>, change_tick: Tick) {
+    pub(crate) unsafe fn replace(&mut self, row: TableRow, data: OwningPtr<'_>) {
         debug_assert!(row.as_usize() < self.len());
         self.data.replace_unchecked(row.as_usize(), data);
     }
@@ -266,7 +266,7 @@ impl Column {
     ///
     /// # Safety
     /// `ptr` must point to valid data of this column's component type
-    pub(crate) unsafe fn push(&mut self, ptr: OwningPtr<'_>, ticks: ComponentTicks) {
+    pub(crate) unsafe fn push(&mut self, ptr: OwningPtr<'_>) {
         self.data.push(ptr);
     }
 

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -141,8 +141,7 @@ impl TableRow {
 /// contiguous buffers internally. An element shares its data across these buffers by using the
 /// same index (i.e. the entity at row 3 has it's data at index 3 and its change detection ticks at
 /// index 3). A slice to these contiguous blocks of memory can be fetched
-/// via [`Column::get_data_slice`], [`Column::get_added_ticks_slice`], and
-/// [`Column::get_changed_ticks_slice`].
+/// via [`Column::get_data_slice`].
 ///
 /// Like many other low-level storage types, [`Column`] has a limited and highly unsafe
 /// interface. It's highly advised to use higher level types and their safe abstractions

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -305,9 +305,7 @@ impl Column {
         (row.as_usize() < self.data.len())
             // SAFETY: The row is length checked before fetching the pointer. This is being
             // accessed through a read-only reference to the column.
-            .then(|| unsafe {
-                self.data.get_unchecked(row.as_usize())
-            })
+            .then(|| unsafe { self.data.get_unchecked(row.as_usize()) })
     }
 
     /// Fetches a read-only reference to the data at `row`.
@@ -364,7 +362,6 @@ impl Column {
     pub fn clear(&mut self) {
         self.data.clear();
     }
-
 }
 
 /// A builder type for constructing [`Table`]s.
@@ -633,7 +630,6 @@ impl Table {
         self.entities.is_empty()
     }
 
-
     /// Iterates over the [`Column`]s of the [`Table`].
     pub fn iter(&self) -> impl Iterator<Item = &Column> {
         self.columns.values()
@@ -771,7 +767,7 @@ mod tests {
     use crate::ptr::OwningPtr;
     use crate::storage::Storages;
     use crate::{
-        component::{Components},
+        component::Components,
         entity::Entity,
         storage::{TableBuilder, TableRow},
     };
@@ -794,10 +790,10 @@ mod tests {
                 let row = table.allocate(*entity);
                 let value: W<TableRow> = W(row);
                 OwningPtr::make(value, |value_ptr| {
-                    table.get_column_mut(component_id).unwrap().initialize(
-                        row,
-                        value_ptr,
-                    );
+                    table
+                        .get_column_mut(component_id)
+                        .unwrap()
+                        .initialize(row, value_ptr);
                 });
             };
         }

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -633,11 +633,6 @@ impl Table {
         self.entities.is_empty()
     }
 
-    pub(crate) fn check_change_ticks(&mut self, change_tick: Tick) {
-        for column in self.columns.values_mut() {
-            column.check_change_ticks(change_tick);
-        }
-    }
 
     /// Iterates over the [`Column`]s of the [`Table`].
     pub fn iter(&self) -> impl Iterator<Item = &Column> {
@@ -751,12 +746,6 @@ impl Tables {
             table.clear();
         }
     }
-
-    pub(crate) fn check_change_ticks(&mut self, change_tick: Tick) {
-        for table in &mut self.tables {
-            table.check_change_ticks(change_tick);
-        }
-    }
 }
 
 impl Index<TableId> for Tables {
@@ -782,7 +771,7 @@ mod tests {
     use crate::ptr::OwningPtr;
     use crate::storage::Storages;
     use crate::{
-        component::{Components, Tick},
+        component::{Components},
         entity::Entity,
         storage::{TableBuilder, TableRow},
     };
@@ -808,7 +797,6 @@ mod tests {
                     table.get_column_mut(component_id).unwrap().initialize(
                         row,
                         value_ptr,
-                        Tick::new(0),
                     );
                 });
             };

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -1,5 +1,5 @@
 use crate::{
-    component::{ComponentId, ComponentInfo, Components, Tick},
+    component::{ComponentId, ComponentInfo, Components},
     entity::Entity,
     query::DebugCheckedUnwrap,
     storage::{blob_vec::BlobVec, ImmutableSparseSet, SparseSet},

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -985,7 +985,7 @@ mod tests {
                     .get_id(TypeId::of::<(W<i32>, W<bool>)>())
                     .expect("Bundle used to spawn entity should exist");
                 let bundle_info = bundles.get(bundle_id).unwrap();
-                let mut bundle_components = bundle_info.components().to_vec();
+                let mut bundle_components = bundle_info.components().collect::<Vec<_>>();
                 bundle_components.sort();
                 for component_id in &bundle_components {
                     assert!(

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -985,7 +985,8 @@ mod tests {
                     .get_id(TypeId::of::<(W<i32>, W<bool>)>())
                     .expect("Bundle used to spawn entity should exist");
                 let bundle_info = bundles.get(bundle_id).unwrap();
-                let mut bundle_components = bundle_info.components().collect::<Vec<_>>();
+                // get all components, including the change detection components
+                let mut bundle_components = bundle_info.iter_all_components().collect::<Vec<_>>();
                 bundle_components.sort();
                 for component_id in &bundle_components {
                     assert!(

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1336,9 +1336,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// * Can always add/remove `Entity`
     /// * `Ref<T>` -> `&T`
     /// * `&mut T` -> `&T`
-    /// * `Mut<T>` -> `&mut T`
-    /// * `Mut<T>` -> Ref<T>
-    /// * `Ref<T>/Mut<T>` -> Changed<T>/Added<T>
+    /// * `Ref<T>` -> `Changed<T>`/`Added<T>`
     /// * [`EntityMut`](crate::world::EntityMut) -> [`EntityRef`](crate::world::EntityRef)
     ///    
     pub fn transmute_lens<NewD: QueryData>(&mut self) -> QueryLens<'_, NewD> {

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1334,9 +1334,11 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// make limited changes to the types of parameters.
     ///
     /// * Can always add/remove `Entity`
-    /// * `Ref<T>` <-> `&T`
+    /// * `Ref<T>` -> `&T`
     /// * `&mut T` -> `&T`
-    /// * `&mut T` -> `Ref<T>`
+    /// * `Mut<T>` -> `&mut T`
+    /// * `Mut<T>` -> Ref<T>
+    /// * `Ref<T>/Mut<T>` -> Changed<T>/Added<T>
     /// * [`EntityMut`](crate::world::EntityMut) -> [`EntityRef`](crate::world::EntityRef)
     ///    
     pub fn transmute_lens<NewD: QueryData>(&mut self) -> QueryLens<'_, NewD> {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1141,9 +1141,10 @@ impl<'w> EntityWorldMut<'w> {
 
         let to_remove = &old_archetype
             .components()
-            .filter(|c| !retained_bundle_info.iter_all_components().any(|comp| comp == *c))
+            .filter(|c| !retained_bundle_info.iter_components().any(|comp| comp == *c))
             .collect::<Vec<_>>();
         let remove_bundle = self.world.bundles.init_dynamic_info(components, to_remove);
+
 
         // SAFETY: Components exist in `remove_bundle` because `Bundles::init_dynamic_info`
         // initializes a `BundleInfo` containing all components in the to_remove Bundle.

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1074,6 +1074,7 @@ impl<'w> EntityWorldMut<'w> {
         }
 
         let old_archetype = &world.archetypes[location.archetype_id];
+        // TODO: should we also send RemovedComponent for ChangeTicks components?
         for component_id in bundle_info.iter_components() {
             if old_archetype.contains(component_id) {
                 world.removed_components.send(component_id, entity);
@@ -1140,7 +1141,7 @@ impl<'w> EntityWorldMut<'w> {
 
         let to_remove = &old_archetype
             .components()
-            .filter(|c| !retained_bundle_info.components().contains(c))
+            .filter(|c| !retained_bundle_info.iter_all_components().contains(c))
             .collect::<Vec<_>>();
         let remove_bundle = self.world.bundles.init_dynamic_info(components, to_remove);
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2257,7 +2257,7 @@ unsafe fn remove_bundle_from_archetype(
             let current_archetype = &mut archetypes[archetype_id];
             let mut removed_table_components = Vec::new();
             let mut removed_sparse_set_components = Vec::new();
-            for component_id in bundle_info.components().iter().cloned() {
+            for component_id in bundle_info.iter_all_components() {
                 if current_archetype.contains(component_id) {
                     // SAFETY: bundle components were already initialized by bundles.get_info
                     let component_info = unsafe { components.get_info_unchecked(component_id) };

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1141,7 +1141,7 @@ impl<'w> EntityWorldMut<'w> {
 
         let to_remove = &old_archetype
             .components()
-            .filter(|c| !retained_bundle_info.iter_all_components().contains(c))
+            .filter(|c| !retained_bundle_info.iter_all_components().any(|comp| comp == *c))
             .collect::<Vec<_>>();
         let remove_bundle = self.world.bundles.init_dynamic_info(components, to_remove);
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1141,10 +1141,13 @@ impl<'w> EntityWorldMut<'w> {
 
         let to_remove = &old_archetype
             .components()
-            .filter(|c| !retained_bundle_info.iter_components().any(|comp| comp == *c))
+            .filter(|c| {
+                !retained_bundle_info
+                    .iter_components()
+                    .any(|comp| comp == *c)
+            })
             .collect::<Vec<_>>();
         let remove_bundle = self.world.bundles.init_dynamic_info(components, to_remove);
-
 
         // SAFETY: Components exist in `remove_bundle` because `Bundles::init_dynamic_info`
         // initializes a `BundleInfo` containing all components in the to_remove Bundle.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2443,6 +2443,7 @@ mod tests {
 
     // For bevy_ecs_macros
     use crate as bevy_ecs;
+    use crate::change_detection::ChangeTicks;
 
     type ID = u8;
 
@@ -2707,36 +2708,40 @@ mod tests {
                 .collect()
         }
 
+        let foo_ticks_id = TypeId::of::<ChangeTicks<Foo>>();
         let foo_id = TypeId::of::<Foo>();
+        let bar_ticks_id = TypeId::of::<ChangeTicks<Bar>>();
         let bar_id = TypeId::of::<Bar>();
+        let baz_ticks_id = TypeId::of::<ChangeTicks<Baz>>();
         let baz_id = TypeId::of::<Baz>();
+        // note that the change detection component is registered before the component
         assert_eq!(
             to_type_ids(world.inspect_entity(ent0)),
-            [Some(foo_id), Some(bar_id), Some(baz_id)].into()
+            [Some(foo_ticks_id), Some(foo_id), Some(bar_ticks_id), Some(bar_id), Some(baz_ticks_id), Some(baz_id)].into()
         );
         assert_eq!(
             to_type_ids(world.inspect_entity(ent1)),
-            [Some(foo_id), Some(bar_id)].into()
+            [Some(foo_ticks_id), Some(foo_id), Some(bar_ticks_id), Some(bar_id)].into()
         );
         assert_eq!(
             to_type_ids(world.inspect_entity(ent2)),
-            [Some(bar_id), Some(baz_id)].into()
+            [Some(bar_ticks_id), Some(bar_id), Some(baz_ticks_id), Some(baz_id)].into()
         );
         assert_eq!(
             to_type_ids(world.inspect_entity(ent3)),
-            [Some(foo_id), Some(baz_id)].into()
+            [Some(foo_ticks_id), Some(foo_id), Some(baz_ticks_id), Some(baz_id)].into()
         );
         assert_eq!(
             to_type_ids(world.inspect_entity(ent4)),
-            [Some(foo_id)].into()
+            [Some(foo_ticks_id), Some(foo_id)].into()
         );
         assert_eq!(
             to_type_ids(world.inspect_entity(ent5)),
-            [Some(bar_id)].into()
+            [Some(bar_ticks_id), Some(bar_id)].into()
         );
         assert_eq!(
             to_type_ids(world.inspect_entity(ent6)),
-            [Some(baz_id)].into()
+            [Some(baz_ticks_id), Some(baz_id)].into()
         );
     }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2070,7 +2070,7 @@ impl World {
                                             ticks.added.check_tick(change_tick);
                                             ticks.changed.check_tick(change_tick);
                                         },
-                                    )
+                                    );
                                 }
                             };
                         }

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -966,9 +966,15 @@ unsafe fn get_component_and_ticks(
     };
 
     // TODO: handle case where component has change detection disabled
-    let change_component_id = world.components().get_info_unchecked(component_id).change_detection_id().unwrap();
+    let change_component_id = world
+        .components()
+        .get_info_unchecked(component_id)
+        .change_detection_id()
+        .unwrap();
     let column = world.fetch_table(location, change_component_id)?;
-    let component_ticks = column.get_data_slice::<ComponentTicks>().get(location.table_row.as_usize())?;
+    let component_ticks = column
+        .get_data_slice::<ComponentTicks>()
+        .get(location.table_row.as_usize())?;
     Some((ptr, component_ticks))
 }
 
@@ -989,7 +995,16 @@ unsafe fn get_ticks(
     entity: Entity,
     location: EntityLocation,
 ) -> Option<ComponentTicks> {
-    let change_component_id = world.components().get_info_unchecked(component_id).change_detection_id().unwrap();
+    let change_component_id = world
+        .components()
+        .get_info_unchecked(component_id)
+        .change_detection_id()
+        .unwrap();
     let column = world.fetch_table(location, change_component_id)?;
-    Some(column.get_data_slice::<ComponentTicks>().get(location.table_row.as_usize())?.read())
+    Some(
+        column
+            .get_data_slice::<ComponentTicks>()
+            .get(location.table_row.as_usize())?
+            .read(),
+    )
 }

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -971,6 +971,11 @@ unsafe fn get_component_and_ticks(
         }
         StorageType::SparseSet => world.fetch_sparse_set(component_id)?.get_with_ticks(entity),
     }
+    // TODO: handle case where component has change detection disabled
+    let change_component_id = world.components().get_info_unchecked(component_id).change_detection_id().unwrap();
+    let column = world.fetch_table(location, change_component_id)?;
+    let ticks = column.get_data_unchecked(location.table_row);
+
 }
 
 /// Get an untyped pointer to the [`ComponentTicks`] on a particular [`Entity`]

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -77,6 +77,7 @@ pub mod prelude {
 
 #[cfg(feature = "bevy_app")]
 use bevy_app::prelude::*;
+use bevy_ecs::change_detection::ChangeTicks;
 
 /// Provides hierarchy functionality to a Bevy app.
 ///
@@ -89,7 +90,9 @@ pub struct HierarchyPlugin;
 impl Plugin for HierarchyPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Children>()
+            .register_type::<ChangeTicks<Children>>()
             .register_type::<Parent>()
+            .register_type::<ChangeTicks<Parent>>()
             .add_event::<HierarchyEvent>();
     }
 }

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -69,13 +69,13 @@ use crate::{
 };
 use bevy_app::{App, AppLabel, Plugin, SubApp};
 use bevy_asset::{load_internal_asset, AssetApp, AssetServer, Handle};
+use bevy_ecs::change_detection::ChangeTicks;
 use bevy_ecs::{prelude::*, schedule::ScheduleLabel, system::SystemState};
 use bevy_utils::tracing::debug;
 use std::{
     ops::{Deref, DerefMut},
     sync::{Arc, Mutex},
 };
-use bevy_ecs::change_detection::ChangeTicks;
 
 /// Contains the default Bevy rendering backend based on wgpu.
 ///

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -75,6 +75,7 @@ use std::{
     ops::{Deref, DerefMut},
     sync::{Arc, Mutex},
 };
+use bevy_ecs::change_detection::ChangeTicks;
 
 /// Contains the default Bevy rendering backend based on wgpu.
 ///
@@ -333,9 +334,13 @@ impl Plugin for RenderPlugin {
             // These types cannot be registered in bevy_color, as it does not depend on the rest of Bevy
             .register_type::<bevy_color::Color>()
             .register_type::<primitives::Aabb>()
+            .register_type::<ChangeTicks<primitives::Aabb>>()
             .register_type::<primitives::CascadesFrusta>()
+            .register_type::<ChangeTicks<primitives::CascadesFrusta>>()
             .register_type::<primitives::CubemapFrusta>()
-            .register_type::<primitives::Frustum>();
+            .register_type::<ChangeTicks<primitives::CubemapFrusta>>()
+            .register_type::<primitives::Frustum>()
+            .register_type::<ChangeTicks<primitives::Frustum>>();
     }
 
     fn ready(&self, app: &App) -> bool {

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -34,6 +34,7 @@ use wgpu::{
     Extent3d, RenderPassColorAttachment, RenderPassDepthStencilAttachment, StoreOp,
     TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
 };
+use bevy_ecs::change_detection::ChangeTicks;
 
 pub const VIEW_TYPE_HANDLE: Handle<Shader> = Handle::weak_from_u128(15421373904451797197);
 
@@ -44,11 +45,14 @@ impl Plugin for ViewPlugin {
         load_internal_asset!(app, VIEW_TYPE_HANDLE, "view.wgsl", Shader::from_wgsl);
 
         app.register_type::<InheritedVisibility>()
+            .register_type::<ChangeTicks<InheritedVisibility>>()
             .register_type::<ViewVisibility>()
+            .register_type::<ChangeTicks<ViewVisibility>>()
             .register_type::<Msaa>()
             .register_type::<NoFrustumCulling>()
             .register_type::<RenderLayers>()
             .register_type::<Visibility>()
+            .register_type::<ChangeTicks<Visibility>>()
             .register_type::<VisibleEntities>()
             .register_type::<ColorGrading>()
             .init_resource::<Msaa>()

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -21,6 +21,7 @@ use crate::{
     Render, RenderApp, RenderSet,
 };
 use bevy_app::{App, Plugin};
+use bevy_ecs::change_detection::ChangeTicks;
 use bevy_ecs::prelude::*;
 use bevy_math::{Mat4, UVec4, Vec3, Vec4, Vec4Swizzles};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
@@ -34,7 +35,6 @@ use wgpu::{
     Extent3d, RenderPassColorAttachment, RenderPassDepthStencilAttachment, StoreOp,
     TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
 };
-use bevy_ecs::change_detection::ChangeTicks;
 
 pub const VIEW_TYPE_HANDLE: Handle<Shader> = Handle::weak_from_u128(15421373904451797197);
 

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -18,6 +18,7 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
+use bevy_ecs::change_detection::ChangeTicks;
 use bevy_ecs::prelude::*;
 use bevy_hierarchy::ValidParentCheckPlugin;
 use bevy_math::{Affine3A, Mat4, Vec3};
@@ -99,7 +100,9 @@ impl Plugin for TransformPlugin {
         struct PropagateTransformsSet;
 
         app.register_type::<Transform>()
+            .register_type::<ChangeTicks<Transform>>()
             .register_type::<GlobalTransform>()
+            .register_type::<ChangeTicks<GlobalTransform>>()
             .add_plugins(ValidParentCheckPlugin::<GlobalTransform>::default())
             .configure_sets(
                 PostStartup,

--- a/examples/ecs/component_hooks.rs
+++ b/examples/ecs/component_hooks.rs
@@ -22,11 +22,17 @@ struct MyComponent(KeyCode);
 
 impl Component for MyComponent {
     const STORAGE_TYPE: StorageType = StorageType::Table;
+    const CHANGE_DETECTION: bool = true;
+    type WriteItem<'w> = Mut<'w, MyComponent>;
 
     /// Hooks can also be registered during component initialisation by
     /// implementing `register_component_hooks`
     fn register_component_hooks(_hooks: &mut ComponentHooks) {
         // Register hooks...
+    }
+
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::WriteItem<'wlong>) -> Self::WriteItem<'wshort> {
+        item
     }
 }
 

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -16,6 +16,7 @@ enum GameState {
 #[derive(Resource)]
 struct BonusSpawnTimer(Timer);
 
+// TODO: example is broken right now. Need to regenerate the scene to include the ChangeTicks<C> components?
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -1,11 +1,11 @@
 //! Demonstrates how Display and Visibility work in the UI.
 
-use std::ops::DerefMut;
 use bevy::winit::WinitSettings;
 use bevy::{
     color::palettes::css::{DARK_GRAY, YELLOW},
     prelude::*,
 };
+use std::ops::DerefMut;
 
 const PALETTE: [&str; 4] = ["27496D", "466B7A", "669DB3", "ADCBE3"];
 const HIDDEN_COLOR: Color = Color::srgb(1.0, 0.7, 0.7);

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -1,5 +1,6 @@
 //! Demonstrates how Display and Visibility work in the UI.
 
+use std::ops::DerefMut;
 use bevy::winit::WinitSettings;
 use bevy::{
     color::palettes::css::{DARK_GRAY, YELLOW},
@@ -446,7 +447,7 @@ fn buttons_handler<T>(
             let mut target_value = left_panel_query.get_mut(target.id).unwrap();
             for &child in children {
                 if let Ok(mut text) = text_query.get_mut(child) {
-                    text.sections[0].value = target.update_target(target_value.as_mut());
+                    text.sections[0].value = target.update_target(target_value.deref_mut());
                     text.sections[0].style.color = if text.sections[0].value.contains("None")
                         || text.sections[0].value.contains("Hidden")
                     {


### PR DESCRIPTION
# Objective

- Remove all special casing for ComponentTicks in storage and add ChangeTicks<T: Component> as an engine provided component.
- Add Component hooks that automatically add or remove the ticks if the component is added/removed. This can be done via hooks or be the only hard-coded part of this.

- Update Archetype change logic:
   - either when `insert::<T: Bundle>` is called, we actually call `insert::<(T::Bundle, T::Bundle::ChangeTicks)>` ?
      PRO:
        - it's possible that we almost don't change the general logic in the bundle.rs file, instead we just have to add the actual bundle, and then add the change detection bundle. (with a Bundle::IS_CHANGE_TICKS to know which one is a change tick?)
      CON:
        - if we add the actual bundle, and then add the change detection bundle; then we double the number of archetype edges?
        - how do we create the value to be inserted for `T::Bundle::ChangeTicks`? the value is different if it's a change or an addition. Also we need to special case the insertion.
   
   - or inside the bundle insertion logic, we do extra logic to spawn the ChangeTick entities
   
   - or update the Bundle's information to change how `component_ids` work
   
   - use observers? but the archetype changes are then deferred; is that ok?

- Update Mut to fetch both &mut T and &mut ChangeTicks<T>.
- Add an associated type to Component that changes WriteFetch to retrieve &mut T when change detection is disabled, and Mut<T> when it isn't. Update the derive macro to enable/disable this behavior.
- Update change detection fetches/filters to rely on Component<Write=Mut<Self>>

## Solution


TODO:
- figure out what to do with disabled change detection components
- add `check_ticks` based on ECS
- test

----------------------------


# Objective

This PR aims to be a proof-of-concept for the issue: https://github.com/bevyengine/bevy/issues/4882 

The general idea is to remove the extra `ComponentTicks` information that is included directly in the `Column` storage type, which now only includes a dense array containing the actual component values.
Instead, the change detection values for a given component `C` are stored inside a separate component `ChangeTicks<C>`.


The implementation is currently pretty ad-hoc, and doesn't make use of new tools such as Observers, which maybe could be used for something like this? I don't know if there's other use cases of 'companion component' in the bevy codebase currently.

## Disabling Change Detection

This potentially opens the door to removing the change detection data for components that don't need it: the main change required would simply be to remove (or not spawn) the `ChangedTicks<C>` component. This could be useful to opt-out of change detection for performance results (for example for some ZSTs).

I don't have this fully working currently, but some general ideas are already there. It might even be possible to make it configurable at runtime, and then the only change would be insert/remove the `ChangedTicks<C>` component.


## Solution

Here's a general outline:

1) Remove the `added_tick` and `change_tick` information that was stored in the `Column` storage type

2) Add an associated constant to the `Component` type to enable/disable change detection for this type. (currently I just use this to disable change detection on the ChangedTicks<C> component, which would trigger an infinite recursion. But there might be other ways to achieve this; I'm not a fan of the associated constant, especially if we want runtime-configuration in the future).

3) Update component initialization to also register a sister component `ChangeTicks<C>`. Update `ComponentInfo` to contain a link to the change detection component's `ComponentId`.

4) Add a `B::ChangeTicks` associated type to `Bundle`, which defines the corresponding change tick components for the bundle. For example `(C1, C2)::ChangeTicks = (ChangedTicks<C1>, ChangedTicks<C2>)`. Update the `Bundle` derive macro to also generate the appropriate `ChangeTicks` associated type.

TODO: I don't really know what to do if some of the components have change detection disabled. For example if I have a bundle (A, B, C) and B has change detection disabled, what should the corresponding ChangeTick type be? Maybe (ChangeTicks<A>, (), ChangeTicks<B>) ?

5) Update the archetype edge logic (add bundle, insert bundle, remove bundle) to take into account the additional `B::ChangeTick` that needs to be added. (i.e when we insert C, we actually also insert ChangeTicks<C> if C::CHANGE_DETECTION is enabled)



