### PR TITLE
dynamic query plan

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -12,6 +12,11 @@ rust-version = "1.86.0"
 
 [features]
 default = ["std", "bevy_reflect", "async_executor", "backtrace"]
+# Testing/internal toggles
+query_uncached_default = []
+
+# Experimental dynamic query support (builder and plan types)
+dynamic_query = []
 
 # Functionality
 

--- a/crates/bevy_ecs/src/query/dynamic.rs
+++ b/crates/bevy_ecs/src/query/dynamic.rs
@@ -1,0 +1,225 @@
+#![cfg(feature = "dynamic_query")]
+use crate::relationship::RelationshipAccessor;
+use crate::world::unsafe_world_cell::UnsafeWorldCell;
+use crate::{
+    archetype::Archetype,
+    change_detection::Tick,
+    component::{ComponentId, Components},
+    entity::Entity,
+    query::{FilteredAccess, WorldQuery},
+    storage::Table,
+};
+use super::dynamic_plan::{Constraint, DynamicPlan, TermVar, VarId};
+use alloc::vec::Vec;
+use smallvec::SmallVec;
+
+#[derive(Clone, Debug)]
+pub struct DynamicResult {
+    pub this: Entity,
+    pub vars: SmallVec<[(VarId, Entity); 3]>,
+}
+
+#[derive(Clone)]
+pub struct DynamicState {
+    pub plan: DynamicPlan,
+}
+
+#[derive(Clone)]
+pub struct DynamicFetch<'w> {
+    world: UnsafeWorldCell<'w>,
+    components: &'w Components,
+    last_run: Tick,
+    this_run: Tick,
+    current_archetype: Option<&'w Archetype>,
+    current_table: Option<&'w Table>,
+}
+
+pub struct DynamicData;
+
+unsafe impl WorldQuery for DynamicData {
+    type Fetch<'w> = DynamicFetch<'w>;
+    type State = DynamicState;
+
+    fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
+        DynamicFetch {
+            world: fetch.world,
+            components: fetch.components,
+            last_run: fetch.last_run,
+            this_run: fetch.this_run,
+            current_archetype: fetch.current_archetype,
+            current_table: fetch.current_table,
+        }
+    }
+
+    unsafe fn init_fetch<'w, 's>(world: UnsafeWorldCell<'w>, _state: &'s Self::State, last_run: Tick, this_run: Tick) -> Self::Fetch<'w> {
+        DynamicFetch {
+            world,
+            components: world.components(),
+            last_run,
+            this_run,
+            current_archetype: None,
+            current_table: None,
+        }
+    }
+
+    const IS_DENSE: bool = false;
+
+    unsafe fn set_archetype<'w, 's>(fetch: &mut Self::Fetch<'w>, _state: &'s Self::State, archetype: &'w Archetype, table: &'w Table) {
+        fetch.current_archetype = Some(archetype);
+        fetch.current_table = Some(table);
+    }
+
+    unsafe fn set_table<'w, 's>(fetch: &mut Self::Fetch<'w>, _state: &'s Self::State, table: &'w Table) {
+        fetch.current_archetype = None;
+        fetch.current_table = Some(table);
+    }
+
+    fn update_component_access(state: &Self::State, access: &mut FilteredAccess) {
+        access.extend(&state.plan.filtered_access);
+    }
+
+    fn init_state(_world: &mut crate::world::World) -> Self::State {
+        panic!("DynamicData::init_state should not be called; build via builder");
+    }
+
+    fn get_state(_components: &Components) -> Option<Self::State> { None }
+
+    fn matches_component_set(state: &Self::State, set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
+        state
+            .plan
+            .filtered_access
+            .filter_sets
+            .iter()
+            .any(|set| {
+                set.with
+                    .ones()
+                    .all(|index| set_contains_id(ComponentId::get_sparse_set_index(index)))
+                    && set
+                        .without
+                        .ones()
+                        .all(|index| !set_contains_id(ComponentId::get_sparse_set_index(index)))
+            })
+    }
+}
+
+unsafe impl crate::query::QueryData for DynamicData {
+    const IS_READ_ONLY: bool = true;
+    type ReadOnly = Self;
+    type Item<'w, 's> = DynamicResult;
+
+    fn shrink<'wlong: 'wshort, 'wshort, 's>(item: Self::Item<'wlong, 's>) -> Self::Item<'wshort, 's> { item }
+
+    unsafe fn fetch<'w, 's>(state: &'s <Self as WorldQuery>::State, fetch: &mut <Self as WorldQuery>::Fetch<'w>, entity: Entity, _table_row: crate::storage::TableRow) -> Self::Item<'w, 's> {
+        let result = solve_bindings(fetch.world, fetch.components, &state.plan, entity);
+        match result {
+            Some(vars) => DynamicResult { this: entity, vars },
+            None => DynamicResult { this: entity, vars: SmallVec::new() },
+        }
+    }
+}
+
+unsafe impl crate::query::ReadOnlyQueryData for DynamicData {}
+
+fn solve_bindings(world: UnsafeWorldCell, components: &Components, plan: &DynamicPlan, this_entity: Entity) -> Option<SmallVec<[(VarId, Entity); 3]>> {
+    let mut bindings: Vec<Option<Entity>> = vec![None; plan.vars.len()];
+    bindings[0] = Some(this_entity);
+
+    let mut changed = true;
+    let mut passes = 0;
+    while changed && passes < plan.constraints.len() + 2 {
+        changed = false;
+        passes += 1;
+        for c in &plan.constraints {
+            match *c {
+                Constraint::With { var, component, .. } => {
+                    if let Some(e) = get_binding(&bindings, var) {
+                        // require presence on bound var
+                        let cell = world.get_entity(e).ok()?;
+                        if !cell.contains_id(component) { return None; }
+                    }
+                }
+                Constraint::Without { var, component } => {
+                    if let Some(e) = get_binding(&bindings, var) {
+                        let cell = world.get_entity(e).ok()?;
+                        if cell.contains_id(component) { return None; }
+                    }
+                }
+                Constraint::Relation { rel, from, to } => {
+                    let info = components.get_info(rel)?;
+                    let accessor = info.relationship_accessor()?;
+                    match (get_binding(&bindings, from), get_binding(&bindings, to), accessor) {
+                        (Some(from_e), None, RelationshipAccessor::Relationship { entity_field_offset, .. }) => {
+                            // read Relationship on `from`
+                            let cell = world.get_entity(from_e).ok()?;
+                            // SAFETY: component id valid; offset used below
+                            let ptr = unsafe { cell.get_by_id(rel)? };
+                            // SAFETY: offset points to Entity field per accessor contract
+                            let target: Entity = unsafe { *ptr.byte_add(entity_field_offset).deref() };
+                            if set_binding(&mut bindings, to, target) { changed = true; }
+                        }
+                        (Some(from_e), Some(to_e), RelationshipAccessor::Relationship { entity_field_offset, .. }) => {
+                            let cell = world.get_entity(from_e).ok()?;
+                            let ptr = unsafe { cell.get_by_id(rel)? };
+                            let target: Entity = unsafe { *ptr.byte_add(entity_field_offset).deref() };
+                            if target != to_e { return None; }
+                        }
+                        (None, Some(to_e), RelationshipAccessor::RelationshipTarget { iter, .. }) => {
+                            // iterate sources of `to` and bind `from` to first match
+                            let cell = world.get_entity(to_e).ok()?;
+                            let ptr = unsafe { cell.get_by_id(rel)? };
+                            // SAFETY: ptr is of correct component type by id; accessor promises safety
+                            let mut it = unsafe { iter(ptr) };
+                            if let Some(src) = it.next() {
+                                if set_binding(&mut bindings, from, src) { changed = true; }
+                            } else {
+                                return None;
+                            }
+                        }
+                        (Some(from_e), Some(to_e), RelationshipAccessor::RelationshipTarget { iter, .. }) => {
+                            let cell = world.get_entity(to_e).ok()?;
+                            let ptr = unsafe { cell.get_by_id(rel)? };
+                            let mut it = unsafe { iter(ptr) };
+                            if !it.any(|src| src == from_e) { return None; }
+                        }
+                        // Other combinations (unbound vars) are deferred to later passes
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
+    // Final validation: all With/Without on bound vars satisfied (already checked), ensure any still-unbound var mentioned in a With must fail
+    for c in &plan.constraints {
+        match *c {
+            Constraint::With { var, .. } | Constraint::Without { var, .. } => {
+                if get_binding(&bindings, var).is_none() { return None; }
+            }
+            _ => {}
+        }
+    }
+
+    let mut out: SmallVec<[(VarId, Entity); 3]> = SmallVec::new();
+    for (idx, b) in bindings.into_iter().enumerate() {
+        if let Some(e) = b { if idx != 0 { out.push((VarId(idx as u32), e)); } }
+    }
+    Some(out)
+}
+
+fn get_binding(bindings: &Vec<Option<Entity>>, var: TermVar) -> Option<Entity> {
+    match var { TermVar::This => bindings[0], TermVar::Var(VarId(i)) => bindings.get(i as usize).and_then(|b| *b) }
+}
+
+fn set_binding(bindings: &mut Vec<Option<Entity>>, var: TermVar, value: Entity) -> bool {
+    match var {
+        TermVar::This => {
+            if let Some(prev) = bindings[0] { prev == value } else { bindings[0] = Some(value); true }
+        }
+        TermVar::Var(VarId(i)) => {
+            let slot = &mut bindings[i as usize];
+            if let Some(prev) = *slot { prev == value } else { *slot = Some(value); true }
+        }
+    }
+}
+
+

--- a/crates/bevy_ecs/src/query/dynamic_plan.rs
+++ b/crates/bevy_ecs/src/query/dynamic_plan.rs
@@ -1,0 +1,40 @@
+#![cfg(feature = "dynamic_query")]
+use crate::component::ComponentId;
+use alloc::vec::Vec;
+use smallvec::SmallVec;
+use super::FilteredAccess;
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct VarId(pub u32);
+
+#[derive(Copy, Clone, Debug)]
+pub enum TermVar { This, Var(VarId) }
+
+#[derive(Clone, Debug)]
+pub enum Constraint {
+    With { var: TermVar, component: ComponentId, write: bool },
+    Without { var: TermVar, component: ComponentId },
+    Relation { rel: ComponentId, from: TermVar, to: TermVar },
+}
+
+#[derive(Clone, Debug)]
+pub struct DynamicPlan {
+    pub vars: SmallVec<[TermVar; 3]>,
+    pub constraints: Vec<Constraint>,
+    pub filtered_access: FilteredAccess,
+}
+
+impl DynamicPlan {
+    pub fn new() -> Self {
+        let mut vars = SmallVec::new();
+        vars.push(TermVar::This);
+        Self { vars, constraints: Vec::new(), filtered_access: FilteredAccess::default() }
+    }
+    pub fn var(&mut self) -> VarId {
+        let id = VarId(self.vars.len() as u32);
+        self.vars.push(TermVar::Var(id));
+        id
+    }
+}
+
+

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -9,6 +9,14 @@ mod iter;
 mod par_iter;
 mod state;
 mod world_query;
+#[cfg(feature = "dynamic_query")]
+mod dynamic_plan;
+#[cfg(feature = "dynamic_query")]
+pub use dynamic_plan::*;
+#[cfg(feature = "dynamic_query")]
+mod dynamic;
+#[cfg(feature = "dynamic_query")]
+pub use dynamic::*;
 
 pub use access::*;
 pub use bevy_ecs_macros::{QueryData, QueryFilter};

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -251,6 +251,34 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         }
     }
 
+    #[cfg(feature = "dynamic_query")]
+    /// Creates a new QueryState from explicit states and a precomputed FilteredAccess.
+    pub fn from_states_uninitialized_with_access(
+        world: &World,
+        fetch_state: <D as WorldQuery>::State,
+        filter_state: <F as WorldQuery>::State,
+        component_access: FilteredAccess,
+        is_dense: bool,
+    ) -> Self {
+        Self {
+            world_id: world.id(),
+            archetype_generation: ArchetypeGeneration::initial(),
+            matched_storage_ids: Vec::new(),
+            is_dense,
+            fetch_state,
+            filter_state,
+            component_access,
+            matched_tables: Default::default(),
+            matched_archetypes: Default::default(),
+            #[cfg(feature = "trace")]
+            par_iter_span: tracing::info_span!(
+                "par_for_each",
+                query = core::any::type_name::<D>(),
+                filter = core::any::type_name::<F>(),
+            ),
+        }
+    }
+
     /// Creates a new [`QueryState`] from a given [`QueryBuilder`] and inherits its [`FilteredAccess`].
     pub fn from_builder(builder: &mut QueryBuilder<D, F>) -> Self {
         let mut fetch_state = D::init_state(builder.world_mut());


### PR DESCRIPTION
I'm wondering how we would evolve the bevy Query type to support multi-term queries.

@quartermeister 's PR would already bring us a long way, since it would allow for things like
Query<(Entity, DockedTo<()>), With<SpaceShip>> (flecs: SpaceShip, (DockedTo, *))
Query<(Entity, DockedTo<(), With<Planet>>), With<SpaceShip>> (flecs: SpaceShip($this), DockedTo($this, $Location), Planet($Location))


But not things like this are probably not possible
SpaceShip($spaceship), 
Faction($spaceship, $spaceship_faction),
DockedTo($spaceship, $planet),
Planet($planet),
RuledBy($planet, $planet_faction),
AlliedWith($spaceship_faction, $planet_faction)

The thing is that bevy's syntax would be complicated by the fact that we need to specify at the same time what data we query (to set the accesses correctly for multithreading systems, etc.) and which entities we query

I guess these kind of complicated multi-term queries would only be dynamic, in which case we could do:
builder
   .with<SpaceShip>(0)
   .related_to<Faction>(0, 1)
   .with<C>(1) // HERE: we add the extra components we want to access on any term
   .related_to<DockedTo>(0, 2)
   .with<Planet>(2)
   .related_to<RuledBy>(2, 3)
   .related_to<AlliedWith>(1, 3)

And then we would do 
builder
   .build::<Dynamic>() // gives us a QueryState<Dynamic, ()>

Where Dynamic is roughly a wrapper around a tuple of FilteredEntityRef/Mut. Maybe we could then call things like dynamic.query<(&C1, &C2)>(1)  which uses transmuting to return a QueryState for the term 1 of the query ($spaceship_faction). The builder needs to store the access for each term to be able to check if the transmutes are valid.


 guess in this scenario my question is how things would related to @quartermeister 's https://github.com/bevyengine/bevy/pull/21557.
IterQueryData and SingleEntityQueryData are definitely necessary pieces, no matter how multi-term queries are implemented
we still need init_nested_access, which would be used by Dynamic to provide the access of non-source terms.
would something like Query<(Entity, DockedTo<()>), With<SpaceShip>> use a nested QueryState, or would we want to convert that QueryState to the dynamic query plan, resolve it there, and then transmute it back to the original type?
would we be able to transmute something like
builder
   .with<SpaceShip>(0)
   .related_to<Faction>(0, 1)
   .with<C>(1)

back to a Query<Faction<&C>> or is that too hard to do? (i.e. if the relationships in the query builder is a tree, it should be able to be transmuted back to a nested QueryStates form)
If it's not possible, then the Query<Faction<&C>> would be a nice UX gain for simple relationship queries. More complicated use-cases could fallback to using the dynamic query builder


So i guess if we were to attempt a prototype:
A) extend QueryBuilder to accept multiple query terms linked by relationships, similar to what james did: https://github.com/bevyengine/bevy/pull/9774/commits/b56e1c7de3af93afe32fb6aacd4e67ec0cede912#diff-b40f95bb6879b8c95b1be48e381a6cb274db01b5919024eb359a4a2feaefb160R6 
we can just do a Vec<FilteredAccess> for now
B) hard: update the matching logic to not use only the access, but use the actual plan
i'm more blurry on this. It seems flecs has some crazy state machine inspired by prolog but I'd like to start with the simplest thing possible.
even without thinking about the logic, this requires a bunch of changes to our matching logic. The matching logic currently just checks if the current access matches. Instead we would be providing a more complex plan. If the plan has no multi-term it can just be the ComponentAccess (for API compatibility with existing QueryData)
C) introduce Dynamic, a WorldQuery that would let you access data dynamically for any of the terms of the query plan
D) support transmutes from parts of dynamic so that we could do dynamic.query::<(&C1, &C2, FilteredEntityRef)>(1) or maybe even dynamic.transmute::<(&C1, ChildOf<&C2, With<C3>>)>. @quartermeister (again!) paved the way with the amazing: https://github.com/bevyengine/bevy/pull/18236



I'm still wondering how to adapt this for Bevy.

Option 1:
- keep QueryIterationCursor roughly as is.
- the `Fetch` is something like your `IterState`, some state that tracks which entities we are tracking
- the `Item` returned is something like a `DynamicIter`, where the user could access components for any of the sources, fix the sources to a specific entity (update `written`)
- D::set_table sets the table for the main source, then for each entity of the main source I struggle to see what `Item`. `D::Fetch` would give you. I guess the `DynamicIter` with the main source already set to the matched entity? 